### PR TITLE
Graph editor clipboard events foundation.

### DIFF
--- a/app/components/graph-editor/README.md
+++ b/app/components/graph-editor/README.md
@@ -232,7 +232,6 @@ methods.
 
 
 # TODO
-- Debug hit detection.
 - Make sure to handle hit testing of custom shapes.
 - Reorder drawable elements on `addSelectedItem`.
 - Zoom and Pan need to be mapped to two-touch gestures.

--- a/app/components/graph-editor/README.md
+++ b/app/components/graph-editor/README.md
@@ -1,4 +1,4 @@
-_Last updated: February 11, 2017_
+_Last updated: February 20, 2017_
 
 # Remarks
 The graph editor component is a custom Angular2 component that is intended to be
@@ -117,7 +117,7 @@ are captured, then the first drawable edge is captured. Drawable elements handle
 their own hit detection logic for both point hit detection and rectangle hit
 detection.
 
-### Input Behavior
+### Input Handling
 Input to the graph editor is handled through mouse events. The `mousedown` event
 starts a timer to determine whether or not a node should be created. The
 `mousemove` event either activates hovering on graph elements, creates a
@@ -129,6 +129,10 @@ being dragged.
 In order to avoid having to check if the graph object has been set in the
 editor, event handler methods and public methods that depend on the graph are
 set to be delegates. Events are just registered and unregistered as needed.
+
+### Clipboard Events
+Handling clipboard events uses some techniques outlined in this blog post:
+https://www.lucidchart.com/techblog/2014/12/02/definitive-guide-copying-pasting-javascript/
 
 ## graph-editor-canvas.ts
 The `GraphEditorCanvas` class separates the majority of the drawing logic from

--- a/app/components/graph-editor/drawable-graph.ts
+++ b/app/components/graph-editor/drawable-graph.ts
@@ -416,13 +416,14 @@ export class DrawableGraph extends Drawable {
      * createNode  
      *   Creates a drawable node.
      */
-    createNode(): DrawableNode | null {
+    createNode(like?: DrawableNode): DrawableNode | null {
         return this.createItem(
-            this._nodes,
-            new DrawableNode(this),
             this._creatingNodeEmitter,
             this._createdNodeEmitter,
-            "nodes"
+            "nodes",
+            this._nodes,
+            new DrawableNode(this, like),
+            like
         );
     }
 
@@ -457,11 +458,12 @@ export class DrawableGraph extends Drawable {
         if (like)
             this.deleteEdge(like);
         return this.createItem(
-            this._edges,
-            new DrawableEdge(this, src, dst, like),
             this._creatingEdgeEmitter,
             this._createdEdgeEmitter,
-            "edges"
+            "edges",
+            this._edges,
+            new DrawableEdge(this, src, dst, like),
+            like
         );
     }
 
@@ -549,14 +551,15 @@ export class DrawableGraph extends Drawable {
      *   Creates a drawable element.
      */
     private createItem<D extends DrawableElement>(
-        items: Set<D>,
-        item: D,
         creatingEmitter: DrawableEventEmitter<D>,
         createdEmitter: DrawableEventEmitter<D>,
-        key: keyof this
+        key: keyof this,
+        items: Set<D>,
+        item: D,
+        like?: D
     ) {
         let old = [...items];
-        let args = new DrawableEventArgs<D>(this, item);
+        let args = new DrawableEventArgs<D>(this, item, like);
         creatingEmitter.emit(args)
         if (args.isCancelled)
             return null;
@@ -622,7 +625,7 @@ export class DrawableGraph extends Drawable {
  *   Event arguments for a drawable event.
  */
 export class DrawableEventArgs<D extends DrawableElement> extends CancellableEventArgs {
-    constructor(source: any, public readonly drawable: D) {
+    constructor(source: any, public readonly drawable: D, public readonly like?: D) {
         super(source);
     }
 }

--- a/app/components/graph-editor/drawable-node.ts
+++ b/app/components/graph-editor/drawable-node.ts
@@ -106,36 +106,36 @@ export class DrawableNode extends DrawableElement {
     /**
      * constructor
      */
-    constructor(graph: DrawableGraph) {
+    constructor(graph: DrawableGraph, like?: DrawableNode) {
         super(graph);
         Object.defineProperties(this, {
             _position: {
                 enumerable: false,
                 writable: true,
                 value: {
-                    x: NODE_PROPERTIES.position.x,
-                    y: NODE_PROPERTIES.position.y
+                    x: (like ? like._position.x + GRID_SPACING : NODE_PROPERTIES.position.x),
+                    y: (like ? like._position.y + GRID_SPACING : NODE_PROPERTIES.position.y),
                 }
             },
             _shape: {
                 enumerable: false,
                 writable: true,
-                value: NODE_PROPERTIES.shape as Shapes
+                value: (like ? like._shape : NODE_PROPERTIES.shape as Shapes)
             },
             _borderColor: {
                 enumerable: false,
                 writable: true,
-                value: NODE_PROPERTIES.borderColor
+                value: (like ? like._borderColor : NODE_PROPERTIES.borderColor)
             },
             _borderStyle: {
                 enumerable: false,
                 writable: true,
-                value: NODE_PROPERTIES.borderStyle as LineStyles
+                value: (like ? like._borderStyle : NODE_PROPERTIES.borderStyle as LineStyles)
             },
             _borderWidth: {
                 enumerable: false,
                 writable: true,
-                value: NODE_PROPERTIES.borderWidth
+                value: (like ? like._borderWidth : NODE_PROPERTIES.borderWidth)
             },
             _size: {
                 enumerable: false,
@@ -253,8 +253,8 @@ export class DrawableNode extends DrawableElement {
             }
         });
         Object.seal(this);
-        this.color = NODE_PROPERTIES.color;
-        this.label = NODE_PROPERTIES.label;
+        this.color = (like ? like._color : NODE_PROPERTIES.color);
+        this.label = (like ? like.label : NODE_PROPERTIES.label);
         this.clearAnchor();
     }
 

--- a/app/components/graph-editor/graph-editor-canvas.ts
+++ b/app/components/graph-editor/graph-editor-canvas.ts
@@ -54,6 +54,12 @@ export type rect = point & size;
  *   Object that handles all of the drawing logic of the graph editor.
  */
 export class GraphEditorCanvas {
+    constructor(private g: CanvasRenderingContext2D) {
+        // These probably don't do anything.
+        this.g.mozImageSmoothingEnabled = true;
+        this.g.msImageSmoothingEnabled = true;
+        this.g.oImageSmoothingEnabled = true;
+    }
 
 
     // Fields //////////////////////////////////////////////////////////////////
@@ -70,17 +76,6 @@ export class GraphEditorCanvas {
      *   The coordinates of the canvas origin.
      */
     private _origin: point = { x: 0, y: 0 };
-
-
-    // Constructor /////////////////////////////////////////////////////////////
-
-
-    constructor(private g: CanvasRenderingContext2D) {
-        // These probably don't do anything.
-        this.g.mozImageSmoothingEnabled = true;
-        this.g.msImageSmoothingEnabled = true;
-        this.g.oImageSmoothingEnabled = true;
-    }
 
 
     // Trace methods ///////////////////////////////////////////////////////////

--- a/app/components/graph-editor/graph-editor.component.css
+++ b/app/components/graph-editor/graph-editor.component.css
@@ -17,8 +17,8 @@ input {
 	position: absolute;
 	bottom: 0;
 	left: 0;
-	width: 10px;
-	height: 10px;
+	width: 0;
+	height: 0;
 	display: block;
 	font-size: 1;
 	z-index: -1;
@@ -27,6 +27,7 @@ input {
 	overflow: hidden;
 	border: none;
 	padding: 0;
+	margin: 0;
 	resize: none;
 	outline: none;
 	-webkit-user-select: text;

--- a/app/components/graph-editor/graph-editor.component.css
+++ b/app/components/graph-editor/graph-editor.component.css
@@ -12,3 +12,23 @@ canvas {
   height: 100%;
   width: 100%;
 }
+
+input {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	width: 10px;
+	height: 10px;
+	display: block;
+	font-size: 1;
+	z-index: -1;
+	color: transparent;
+	background: transparent;
+	overflow: hidden;
+	border: none;
+	padding: 0;
+	resize: none;
+	outline: none;
+	-webkit-user-select: text;
+	user-select: text; /* Because for user-select:none, Safari won't allow input */
+}

--- a/app/components/graph-editor/graph-editor.component.html
+++ b/app/components/graph-editor/graph-editor.component.html
@@ -1,5 +1,5 @@
 <div>
   <canvas #sinapGraphEditorCanvas tabindex="0" (window:resize)="resize()">
+    <input #hiddenInput type="text" value="" />
   </canvas>
-  <input #hiddenInput type="text" value="" />
 </div>

--- a/app/components/graph-editor/graph-editor.component.html
+++ b/app/components/graph-editor/graph-editor.component.html
@@ -1,7 +1,5 @@
 <div>
-  <canvas
-    #sinapGraphEditorCanvas
-    tabindex="1"
-    (window:resize)="resize()">
+  <canvas #sinapGraphEditorCanvas tabindex="0" (window:resize)="resize()">
   </canvas>
+  <input #hiddenInput type="text" value="" />
 </div>

--- a/app/components/graph-editor/graph-editor.component.ts
+++ b/app/components/graph-editor/graph-editor.component.ts
@@ -314,8 +314,20 @@ export class GraphEditorComponent implements AfterViewInit {
 
     private onCopy
     = (e: ClipboardEvent) => {
+        const dt = e.clipboardData;
+        dt.clearData();
+        dt.dropEffect = "copy";
+        dt.effectAllowed = "copy";
+
         // TODO:
-        // Deal with this.
+        // Needs discussion: In order to get this to work according to the
+        // example in this blog post:
+        // https://www.lucidchart.com/techblog/2014/12/02/definitive-guide-copying-pasting-javascript/
+        // the graph editor needs access to a serializer and deserializer for
+        // the graph elements.
+        
+        // dt.setData("application/sinapObjects", )
+        e.preventDefault();
     }
 
     private onCut

--- a/app/components/main/main.component.ts
+++ b/app/components/main/main.component.ts
@@ -191,22 +191,13 @@ export class MainComponent implements OnInit, MenuEventListener, REPLDelegate, T
                 this.saveFile();
                 break;
             case MenuEventAction.CUT:
-                if (this.focusIsChildOf("editor-panel")) {
-                    this.graphEditor.cut();
-                    e.preventDefault();
-                }
+                document.execCommand("cut");
                 break;
             case MenuEventAction.COPY:
-                if (this.focusIsChildOf("editor-panel")) {
-                    this.graphEditor.copy();
-                    e.preventDefault();
-                }
+                document.execCommand("copy");
                 break;
             case MenuEventAction.PASTE:
-                if (this.focusIsChildOf("editor-panel")) {
-                    this.graphEditor.paste();
-                    e.preventDefault();
-                }
+                document.execCommand("paste");
                 break;
             case MenuEventAction.CLOSE:
                 if (this.context) {
@@ -225,6 +216,13 @@ export class MainComponent implements OnInit, MenuEventListener, REPLDelegate, T
 
     /**
      * Return true if the focused element is a child of an element with an `id` of `childOf`
+     * 
+     * Dear @RighteousRaichu,
+     * 
+     * I just made this useless.
+     * 
+     * With love,
+     * @ilargierdi
      */
     private focusIsChildOf(childOf: string) {
         function elementIsChildOf(element: Element, id: string): boolean {

--- a/app/components/main/main.component.ts
+++ b/app/components/main/main.component.ts
@@ -199,6 +199,20 @@ export class MainComponent implements OnInit, MenuEventListener, REPLDelegate, T
             case MenuEventAction.PASTE:
                 document.execCommand("paste");
                 break;
+            case MenuEventAction.DELETE:
+                if (this.focusIsChildOf("editor-panel"))
+                    this.graphEditor.deleteSelected();
+                else
+                    document.execCommand("delete");
+                break;
+            case MenuEventAction.SELECT_ALL:
+                // TODO:
+                // This isn't working on Windows.
+                if (this.focusIsChildOf("editor-panel"))
+                    this.graphEditor.selectAll();
+                else
+                    document.execCommand("selectAll");
+                break;
             case MenuEventAction.CLOSE:
                 if (this.context) {
                     this.tabBar.deleteTab(this.context.index);
@@ -216,28 +230,17 @@ export class MainComponent implements OnInit, MenuEventListener, REPLDelegate, T
 
     /**
      * Return true if the focused element is a child of an element with an `id` of `childOf`
-     * 
-     * Dear @RighteousRaichu,
-     * 
-     * I just made this useless.
-     * 
-     * With love,
-     * @ilargierdi
      */
     private focusIsChildOf(childOf: string) {
-        function elementIsChildOf(element: Element, id: string): boolean {
-            while (element.parentElement) {
-                if (element.parentElement.id == id) {
-                    return true;
-                } else {
-                    return elementIsChildOf(element.parentElement, id);
-                }
-            }
-
-            return false;
+        console.log(childOf)
+        let el: Element | null = document.activeElement;
+        while (el && document.hasFocus()) {
+            console.log(el)
+            if (el.id == childOf)
+                return true;
+            el = el.parentElement;
         }
-
-        return document.hasFocus() && elementIsChildOf(document.activeElement, childOf);
+        return false;
     }
 
     saveFile() {

--- a/app/components/main/main.component.ts
+++ b/app/components/main/main.component.ts
@@ -190,28 +190,17 @@ export class MainComponent implements OnInit, MenuEventListener, REPLDelegate, T
             case MenuEventAction.SAVE_FILE:
                 this.saveFile();
                 break;
-            case MenuEventAction.CUT:
-                document.execCommand("cut");
-                break;
-            case MenuEventAction.COPY:
-                document.execCommand("copy");
-                break;
-            case MenuEventAction.PASTE:
-                document.execCommand("paste");
-                break;
             case MenuEventAction.DELETE:
-                if (this.focusIsChildOf("editor-panel"))
+                if (this.focusIsChildOf("editor-panel")) {
                     this.graphEditor.deleteSelected();
-                else
-                    document.execCommand("delete");
+                    e.preventDefault();
+                }
                 break;
             case MenuEventAction.SELECT_ALL:
-                // TODO:
-                // This isn't working on Windows.
-                if (this.focusIsChildOf("editor-panel"))
+                if (this.focusIsChildOf("editor-panel")) {
                     this.graphEditor.selectAll();
-                else
-                    document.execCommand("selectAll");
+                    e.preventDefault();
+                }
                 break;
             case MenuEventAction.CLOSE:
                 if (this.context) {
@@ -232,10 +221,8 @@ export class MainComponent implements OnInit, MenuEventListener, REPLDelegate, T
      * Return true if the focused element is a child of an element with an `id` of `childOf`
      */
     private focusIsChildOf(childOf: string) {
-        console.log(childOf)
         let el: Element | null = document.activeElement;
         while (el && document.hasFocus()) {
-            console.log(el)
             if (el.id == childOf)
                 return true;
             el = el.parentElement;

--- a/app/models/menu.ts
+++ b/app/models/menu.ts
@@ -8,6 +8,8 @@ export enum MenuEventAction {
     CUT,
     COPY,
     PASTE,
+    DELETE,
+    SELECT_ALL,
     SAVE_FILE,
     LOAD_FILE,
     CLOSE,
@@ -76,10 +78,14 @@ var editMenu: Electron.MenuItemOptions = {
             click: clickHandlerMake(MenuEventAction.PASTE)
         },
         {
-            role: 'delete'
+            label: 'Delete',
+            accelerator: (process.platform === 'darwin' ? 'Backspace' : 'Delete'),
+            click: clickHandlerMake(MenuEventAction.DELETE)
         },
         {
-            role: 'selectall'
+            label: 'Select All',
+            accelerator: 'CmdOrCtrl+a',
+            click: clickHandlerMake(MenuEventAction.SELECT_ALL)
         },
     ]
 };

--- a/app/services/menu.service.ts
+++ b/app/services/menu.service.ts
@@ -89,6 +89,10 @@ export class MenuService {
                 return makeAction("copy");
             case MenuEventAction.PASTE:
                 return makeAction("paste");
+            case MenuEventAction.SELECT_ALL:
+                return makeAction("selectAll");
+            case MenuEventAction.DELETE:
+                return makeAction("delete");
             case MenuEventAction.CLOSE:
                 if (process.platform === 'darwin') {
                     return remote.BrowserWindow.getFocusedWindow().close;


### PR DESCRIPTION
This PR is mainly to push some changes on `main.component`. Please ensure that it works on MacOS. In particular, make sure that delete still works as expected for the editor.

* Added foundation for clipboard events on the graph editor.
  - The editor currently has no implementation of cut/copy/paste; I'm waiting for (de)serialization for the clipboard events. If this is a problem, I can probably hack a temp solution, but I'd like the changes to `main.component` to be merged into master.
* Added a couple of menu events to redirect some of the menu functionality to the editor.