### PR TITLE
Graph editor images

### DIFF
--- a/app/components/graph-editor/defaults.ts
+++ b/app/components/graph-editor/defaults.ts
@@ -104,6 +104,8 @@ export const NODE_PROPERTIES = {
     get position() { return { get x() { return 0; }, get y() { return 0; } }; },
     get label() { return ""; },
     get shape() { return "circle"; },
+    get image() { return ""; },
+    get anchorPoints() { return []; },
     get color() { return "#fff200"; },
     get borderColor() { return "#000"; },
     get borderStyle() { return "solid"; },

--- a/app/components/graph-editor/drawable-edge.ts
+++ b/app/components/graph-editor/drawable-edge.ts
@@ -25,39 +25,39 @@ import * as MathEx from "./math";
 
 
 /**
- * DrawableEdge  
+ * DrawableEdge
  *   Represents an edge that is drawn on the graph editor canvas.
  */
 export class DrawableEdge extends DrawableElement {
 
     /**
-     * _srcArrow  
+     * _srcArrow
      *   Keeps track of whether or not the source arrow is displayed.
      */
     private _srcArrow: boolean;
 
     /**
-     * _dstArrow  
+     * _dstArrow
      *   Keeps track of whether or not the destination arrow is displayed.
      */
     private _dstArrow: boolean;
 
     /**
-     * _lineStyle  
+     * _lineStyle
      *   Keeps track of the line style of the edge.
      */
     private _lineStyle: LineStyles;
 
     /**
-     * _lineWidth  
+     * _lineWidth
      *   Keeps track of the line width of the edge.
      */
     private _lineWidth: number;
 
     /**
-     * _pts  
+     * _pts
      *   Keeps track of points-of-interest related to the edge.
-     * 
+     *
      * <p>
      *   The first two points represent the boundary points along the source and
      *   destination nodes respectively. The third point is the midpoint along
@@ -69,19 +69,19 @@ export class DrawableEdge extends DrawableElement {
     private _pts: point[];
 
     /**
-     * _spt  
+     * _spt
      *   The bound anchor point of the source node.
      */
     private _spt: point | null;
 
     /**
-     * _dpt  
+     * _dpt
      *   The bound anchor point of the destination node.
      */
     private _dpt: point | null;
 
     /**
-     * constructor  
+     * constructor
      */
     constructor(
         graph: DrawableGraph,
@@ -203,61 +203,61 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * source  
+     * source
      *   Gets the reference to the drawable source node of the edge.
      */
     readonly source: DrawableNode;
 
     /**
-     * destination  
+     * destination
      *   Gets the reference to the drawable destination node of the edge.
      */
     readonly destination: DrawableNode;
 
     /**
-     * sourcePoint  
+     * sourcePoint
      *   Gets the point of the edge along the boundary of its source node.
      */
     readonly sourcePoint: point;
 
     /**
-     * destinationPoint  
+     * destinationPoint
      *   Gets the point of the edge along the boundary of its destination node.
      */
     readonly destinationPoint: point;
 
     /**
-     * showSourceArrow  
+     * showSourceArrow
      *   Gets or sets whether or not an arrow should be displayed towards the
      *   source node.
      */
     showSourceArrow: boolean;
 
     /**
-     * showDestinationArrow  
+     * showDestinationArrow
      *   Gets or sets whether or not an arrow should be displayed towards the
      *   destination node.
      */
     showDestinationArrow: boolean;
 
     /**
-     * lineStyle  
+     * lineStyle
      *   Gets or sets the line style of the edge.
      */
     lineStyle: LineStyles;
 
     /**
-     * lineWidth  
+     * lineWidth
      *   Gets or sets the width of the line of the edge.
      */
     lineWidth: number;
 
     /**
-     * points  
+     * points
      *   Updates the points-of-interest related to the edge.
      */
     private set points(value: point[]) {
-        if (this._pts.length == value.length) {
+        if (this._pts.length === value.length) {
             for (let i = 0; i < value.length; i++)
                 this._pts[i] = value[i];
         }
@@ -266,7 +266,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * update  
+     * update
      *   Updates the geometry and draw logic of the edge.
      */
     update(g: GraphEditorCanvas): void {
@@ -287,7 +287,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * updateDraw  
+     * updateDraw
      *   Updates the draw logic of the edge.
      */
     updateDraw(g: GraphEditorCanvas) {
@@ -310,7 +310,7 @@ export class DrawableEdge extends DrawableElement {
                 const size = {
                     h: this._textSize.h + 4,
                     w: this._textSize.w + 4
-                }
+                };
                 drawLabelThunk = () => {
                     g.lineWidth = this._lineWidth;
                     g.fillStyle = SELECTION_COLOR;
@@ -325,7 +325,7 @@ export class DrawableEdge extends DrawableElement {
                 drawLabelThunk();
                 g.shadowBlur = 0;
                 g.globalAlpha = 1;
-            }
+            };
             hovered = false;
         }
         else {
@@ -361,9 +361,9 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * hitPoint  
+     * hitPoint
      *   Tests whether or not a point is within the hit threshold of the edge.
-     * 
+     *
      * @returns
      *   An anchor point if the given point is within the threshold of the edge;
      *   otherwise, null.
@@ -434,7 +434,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * hitRect  
+     * hitRect
      *   Tests if any part of the edge is captured by a rectangle.
      */
     hitRect(r: rect): boolean {
@@ -476,7 +476,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * bindAnchor  
+     * bindAnchor
      *   Binds an end point of the edge to a node anchor.
      */
     bindAnchor(n: DrawableNode, apt: point) {
@@ -487,7 +487,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * unbindAnchor  
+     * unbindAnchor
      *   Unbinds an end point of the edge from a node anchor.
      */
     unbindAnchor(n: DrawableNode) {
@@ -498,7 +498,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * updateOverlappedEdges  
+     * updateOverlappedEdges
      */
     private updateOverlappedEdges(g: GraphEditorCanvas) {
         if (!this.src.isHidden && !this.dst.isHidden) {
@@ -542,7 +542,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * setStraightPoints  
+     * setStraightPoints
      *   Sets the end points and midpoint of a straight line.
      */
     private setStraightPoints(): void {
@@ -588,7 +588,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * setQuadraticPoints  
+     * setQuadraticPoints
      *   Sets the edge points and midpoint of an overlapping edge.
      */
     private setQuadraticPoints(): void {
@@ -651,7 +651,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * setLoopPoints  
+     * setLoopPoints
      *   Sets the edge points and midpoint of a self-referencing node.
      */
     private setLoopPoints(): void {
@@ -708,7 +708,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * makePreDrawEdge  
+     * makePreDrawEdge
      *   Makes a function that sets up the canvas for drawing an edge.
      */
     private makePreDrawEdge(
@@ -738,11 +738,11 @@ export class DrawableEdge extends DrawableElement {
             g.strokeStyle = color;
             g.lineWidth = lineWidth;
             g.lineStyle = { style: lineStyle };
-        }
+        };
     }
 
     /**
-     * makeTraceEdge  
+     * makeTraceEdge
      *   Makes a function that traces the geometry of an edge.
      */
     private makeTraceEdge(g: GraphEditorCanvas): () => void {
@@ -794,7 +794,7 @@ export class DrawableEdge extends DrawableElement {
                 else
                     return () => {
                         g.traceQuadratic(pts[0], pts[1], pts[3]);
-                    }
+                    };
 
             // Linear
             default:
@@ -821,7 +821,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * drawLabelRect  
+     * drawLabelRect
      *   Draws the background rectangle for the edge label.
      */
     private drawLabelRect(g: GraphEditorCanvas, sz: size) {
@@ -836,7 +836,7 @@ export class DrawableEdge extends DrawableElement {
     }
 
     /**
-     * drawEdgeLabel  
+     * drawEdgeLabel
      *   Draws the edge label.
      */
     private drawLabel(g: GraphEditorCanvas): void {
@@ -849,7 +849,7 @@ export class DrawableEdge extends DrawableElement {
 
 
 /**
- * hitPtTestLine  
+ * hitPtTestLine
  *   Tests if a point is within the threshold of a straight line segment.
  */
 function hitPtTestLine(
@@ -890,7 +890,7 @@ function hitPtTestLine(
 }
 
 /**
- * hitRectTestStraighEdge  
+ * hitRectTestStraighEdge
  *   Test whether any part of a straight line has been captured by a rectangle.
  */
 function hitRectTestStraighEdge(

--- a/app/components/graph-editor/drawable-edge.ts
+++ b/app/components/graph-editor/drawable-edge.ts
@@ -132,7 +132,7 @@ export class DrawableEdge extends DrawableElement {
                 enumerable: true,
                 get: () => this._srcArrow,
                 set: (value: boolean) => {
-                    let old = this._srcArrow;
+                    const old = this._srcArrow;
                     if (this._srcArrow !== value) {
                         this._srcArrow = value;
                         this.onPropertyChanged("showSourceArrow", old);
@@ -143,7 +143,7 @@ export class DrawableEdge extends DrawableElement {
                 enumerable: true,
                 get: () => this._dstArrow,
                 set: (value: boolean) => {
-                    let old = this._dstArrow;
+                    const old = this._dstArrow;
                     if (this._dstArrow !== value) {
                         this._dstArrow = value;
                         this.onPropertyChanged("showDestinationArrow", old);
@@ -154,7 +154,7 @@ export class DrawableEdge extends DrawableElement {
                 enumerable: true,
                 get: () => this._lineStyle,
                 set: (value: LineStyles) => {
-                    let old = this._lineStyle;
+                    const old = this._lineStyle;
                     if (this._lineStyle !== value) {
                         this._lineStyle = value;
                         this.onPropertyChanged("lineStyle", old);
@@ -165,7 +165,7 @@ export class DrawableEdge extends DrawableElement {
                 enumerable: true,
                 get: () => this._lineWidth,
                 set: (value: number) => {
-                    let old = this._lineWidth;
+                    const old = this._lineWidth;
                     if (this._lineWidth !== value) {
                         this._lineWidth = value;
                         this.onPropertyChanged("lineWidth", old);
@@ -274,7 +274,7 @@ export class DrawableEdge extends DrawableElement {
         // Set selected shadow //
         /////////////////////////
         if (this.isSelected) {
-            let preDrawThunk = this.makePreDrawEdge(
+            const preDrawThunk = this.makePreDrawEdge(
                 g,
                 SELECTION_COLOR,
                 this._lineWidth + 4,
@@ -282,10 +282,10 @@ export class DrawableEdge extends DrawableElement {
                 false,
                 this.isHovered
             );
-            let traceThunk = this.makeTraceEdge(g);
+            const traceThunk = this.makeTraceEdge(g);
             let drawLabelThunk = () => { };
             if (this._lines.length > 0) {
-                let size = {
+                const size = {
                     h: this._textSize.h + 4,
                     w: this._textSize.w + 4
                 }
@@ -312,7 +312,7 @@ export class DrawableEdge extends DrawableElement {
         //////////////
         // Set edge //
         //////////////
-        let preDrawThunk = this.makePreDrawEdge(
+        const preDrawThunk = this.makePreDrawEdge(
             g,
             this._color,
             this._lineWidth,
@@ -320,7 +320,7 @@ export class DrawableEdge extends DrawableElement {
             this.isDragging,
             hovered
         );
-        let traceThunk = this.makeTraceEdge(g);
+        const traceThunk = this.makeTraceEdge(g);
         let drawLabelThunk = () => { };
         if (this._lines.length > 0) {
             drawLabelThunk = () => {
@@ -348,16 +348,16 @@ export class DrawableEdge extends DrawableElement {
      */
     hitPoint(pt: point): point | null {
         if (!(this.src.isHidden || this.dst.isHidden)) {
-            let src = this._pts[0];
-            let dst = this._pts[1];
-            let mid = this._pts[2];
-            let margin = this._lineWidth * this._lineWidth + EDGE_HIT_MARGIN * EDGE_HIT_MARGIN;
+            const src = this._pts[0];
+            const dst = this._pts[1];
+            const mid = this._pts[2];
+            const margin = this._lineWidth * this._lineWidth + EDGE_HIT_MARGIN * EDGE_HIT_MARGIN;
 
-            let tl = {
+            const tl = {
                 x: Math.min(src.x, dst.x, mid.x) - margin,
                 y: Math.min(src.y, dst.y, mid.y) - margin
             };
-            let br = {
+            const br = {
                 x: Math.max(src.x, dst.x, mid.x) + margin,
                 y: Math.max(src.y, dst.y, mid.y) + margin
             };
@@ -365,21 +365,21 @@ export class DrawableEdge extends DrawableElement {
                 switch (this._pts.length) {
                     // Cubic Bezier.
                     case 7: {
-                        let pt1 = this._pts[3];
-                        let pt2 = this._pts[4];
+                        const pt1 = this._pts[3];
+                        const pt2 = this._pts[4];
                         let hitPt1 = hitPtTestLine(src, pt1, pt, margin);
-                        let hitPt2 = hitPtTestLine(pt1, pt2, pt, margin);
+                        const hitPt2 = hitPtTestLine(pt1, pt2, pt, margin);
                         let hitPt3 = hitPtTestLine(pt2, dst, pt, margin);
                         if (hitPt2 === pt1 || hitPt1 === pt1)
                             hitPt1 = src;
                         else if (hitPt2 === pt2 || hitPt3 === pt2)
                             hitPt3 = dst;
                         if (hitPt1 && hitPt3) {
-                            let v = { x: pt.x - src.x, y: pt.y - src.y };
-                            let d1 = MathEx.dot(v, v);
+                            const v = { x: pt.x - src.x, y: pt.y - src.y };
+                            const d1 = MathEx.dot(v, v);
                             v.x = pt.x - dst.x;
                             v.y = pt.y - dst.y;
-                            let d2 = MathEx.dot(v, v);
+                            const d2 = MathEx.dot(v, v);
                             return (d2 < d1 ? dst : src);
                         }
                         else if (hitPt1)
@@ -401,7 +401,7 @@ export class DrawableEdge extends DrawableElement {
 
                     // Straight Line.
                     default: {
-                        let hitPt = hitPtTestLine(src, dst, pt, margin);
+                        const hitPt = hitPtTestLine(src, dst, pt, margin);
                         if (hitPt)
                             return hitPt;
                     } break;
@@ -420,10 +420,10 @@ export class DrawableEdge extends DrawableElement {
         const R = r.x + r.w;
         const T = r.y;
         const B = r.y + r.h;
-        let ps = this._pts;
-        let p0 = ps[0];
-        let p1 = ps[1];
-        let p2 = ps[2];
+        const ps = this._pts;
+        const p0 = ps[0];
+        const p1 = ps[1];
+        const p2 = ps[2];
         const inside = (p: point) => {
             return (p.x <= R && p.x >= L && p.y <= B && p.y >= T);
         };
@@ -458,14 +458,14 @@ export class DrawableEdge extends DrawableElement {
      */
     private updateOverlappedEdges(g: GraphEditorCanvas) {
         if (!this.src.isHidden && !this.dst.isHidden) {
-            let srcIn = this.source.incomingEdges;
-            let srcOut = this.source.outgoingEdges;
-            let dstIn = this.destination.incomingEdges;
-            let dstOut = this.destination.outgoingEdges;
-            let opposing = new Set<DrawableEdge>(
+            const srcIn = this.source.incomingEdges;
+            const srcOut = this.source.outgoingEdges;
+            const dstIn = this.destination.incomingEdges;
+            const dstOut = this.destination.outgoingEdges;
+            const opposing = new Set<DrawableEdge>(
                 [...dstOut].filter(v => srcIn.has(v))
             );
-            let adjacent = new Set<DrawableEdge>(
+            const adjacent = new Set<DrawableEdge>(
                 [...srcOut].filter(v => dstIn.has(v))
             );
             if (opposing.size > 0) {
@@ -502,12 +502,12 @@ export class DrawableEdge extends DrawableElement {
      *   Sets the end points and midpoint of a straight line.
      */
     private setStraightPoints(): void {
-        let pts: point[] = [];
-        let spt = this.src.position;
-        let dpt = this.dst.position;
-        let v = { x: dpt.x - spt.x, y: dpt.y - spt.y };
-        let d = MathEx.mag(v);
-        let u = { x: v.x / d, y: v.y / d };
+        const pts: point[] = [];
+        const spt = this.src.position;
+        const dpt = this.dst.position;
+        const v = { x: dpt.x - spt.x, y: dpt.y - spt.y };
+        const d = MathEx.mag(v);
+        const u = { x: v.x / d, y: v.y / d };
         if (!this.src.isHidden)
             pts.push(this.src.getBoundaryPt(u));
         else
@@ -534,7 +534,7 @@ export class DrawableEdge extends DrawableElement {
         let spt = this.src.position;
         let dpt = this.dst.position;
         // Get a vector from the source node to the destination node.
-        let v: point = { x: dpt.x - spt.x, y: dpt.y - spt.y, };
+        const v: point = { x: dpt.x - spt.x, y: dpt.y - spt.y, };
         // Get the magitude of the vector.
         let d = MathEx.mag(v);
 
@@ -546,7 +546,7 @@ export class DrawableEdge extends DrawableElement {
 
         // Set the control point to the midpoint of the vector plus the scaled
         // normal.
-        let pt1: point = {
+        const pt1: point = {
             x: spt.x + v.x / 2 + v.y / d * GRID_SPACING,
             y: spt.y + v.y / 2 - v.x / d * GRID_SPACING
         };
@@ -554,14 +554,14 @@ export class DrawableEdge extends DrawableElement {
         v.x = pt1.x - this.src.position.x;
         v.y = pt1.y - this.src.position.y;
         d = MathEx.mag(v);
-        let pt0 = this.src.getBoundaryPt({ x: v.x / d, y: v.y / d });
+        const pt0 = this.src.getBoundaryPt({ x: v.x / d, y: v.y / d });
         // Get the destination endpoint.
         v.x = pt1.x - this.dst.position.x;
         v.y = pt1.y - this.dst.position.y;
         d = MathEx.mag(v);
-        let pt2 = this.dst.getBoundaryPt({ x: v.x / d, y: v.y / d });
+        const pt2 = this.dst.getBoundaryPt({ x: v.x / d, y: v.y / d });
         // Translate the controlpoint by the position of the source node.
-        let pts: point[] = [];
+        const pts: point[] = [];
         pts.push(pt0);
         pts.push(pt2);
         // Midpoint.
@@ -578,20 +578,20 @@ export class DrawableEdge extends DrawableElement {
      *   Sets the edge points and midpoint of a self-referencing node.
      */
     private setLoopPoints(): void {
-        let spt = this.src.position;
-        let u: point = { x: MathEx.SIN_22_5, y: -MathEx.COS_22_5 };
-        let v: point = { x: -MathEx.SIN_22_5, y: -MathEx.COS_22_5 };
-        let pt0: point = this.src.getBoundaryPt(u);
-        let pt1: point = this.src.getBoundaryPt(v);
-        let pt2: point = {
+        const spt = this.src.position;
+        const u: point = { x: MathEx.SIN_22_5, y: -MathEx.COS_22_5 };
+        const v: point = { x: -MathEx.SIN_22_5, y: -MathEx.COS_22_5 };
+        const pt0: point = this.src.getBoundaryPt(u);
+        const pt1: point = this.src.getBoundaryPt(v);
+        const pt2: point = {
             x: pt0.x + 2 * GRID_SPACING * u.x,
             y: pt0.y + 2 * GRID_SPACING * u.y
         };
-        let pt3: point = {
+        const pt3: point = {
             x: pt1.x + 2 * GRID_SPACING * v.x,
             y: pt1.y + 2 * GRID_SPACING * v.y
         };
-        let pts: point[] = [];
+        const pts: point[] = [];
         // src
         pts.push(pt0);
         // dst
@@ -655,9 +655,9 @@ export class DrawableEdge extends DrawableElement {
      *   Makes a function that traces the geometry of an edge.
      */
     private makeTraceEdge(g: GraphEditorCanvas): () => void {
-        let pts = this._pts;
-        let showSrc = this._srcArrow;
-        let showDst = this._dstArrow;
+        const pts = this._pts;
+        const showSrc = this._srcArrow;
+        const showDst = this._dstArrow;
         switch (pts.length) {
             // Cubic
             case 7:
@@ -734,7 +734,7 @@ export class DrawableEdge extends DrawableElement {
      *   Draws the background rectangle for the edge label.
      */
     private drawLabelRect(g: GraphEditorCanvas, sz: size) {
-        let pt = this._pts[2];
+        const pt = this._pts[2];
         g.traceRect(makeRect(
             { x: pt.x - sz.w / 2 - 6, y: pt.y - sz.h / 2 },
             { x: pt.x + sz.w / 2 + 6, y: pt.y + sz.h / 2 }
@@ -768,30 +768,30 @@ function hitPtTestLine(
     margin: number
 ): point | null {
     // Edge vector src -> dst
-    let ve = {
+    const ve = {
         x: dst.x - src.x,
         y: dst.y - src.y,
     };
     // Cursor vector e.src -> cursor
-    let vm = {
+    const vm = {
         x: pt.x - src.x,
         y: pt.y - src.y
     };
-    let dotee = MathEx.dot(ve, ve); // edge dot edge
-    let dotem = MathEx.dot(ve, vm); // edge dot cursor
+    const dotee = MathEx.dot(ve, ve); // edge dot edge
+    const dotem = MathEx.dot(ve, vm); // edge dot cursor
     // Projection vector cursor -> edge
-    let p = {
+    const p = {
         x: ve.x * dotem / dotee,
         y: ve.y * dotem / dotee
     };
     // Rejection vector cursor -^ edge
-    let r = { x: vm.x - p.x, y: vm.y - p.y };
+    const r = { x: vm.x - p.x, y: vm.y - p.y };
 
-    let dotpp = MathEx.dot(p, p); // proj dot proj
-    let dotrr = MathEx.dot(r, r); // rej dot rej
+    const dotpp = MathEx.dot(p, p); // proj dot proj
+    const dotrr = MathEx.dot(r, r); // rej dot rej
 
-    let dep = { x: ve.x - p.x, y: ve.y - p.y };
-    let dotdep = MathEx.dot(dep, dep);
+    const dep = { x: ve.x - p.x, y: ve.y - p.y };
+    const dotdep = MathEx.dot(dep, dep);
 
     if (dotpp <= dotee && dotdep <= dotee && dotrr < margin)
         return (dotpp < dotee / 4 ? src : dst);
@@ -810,7 +810,7 @@ function hitRectTestStraighEdge(
     p0: point,
     p1: point
 ): boolean {
-    let intersect = (
+    const intersect = (
         i: number,      // Intersect line.
         px: number,     // p0 "x"-coordinate
         py: number,     // p0 "y"-coordinate
@@ -826,8 +826,8 @@ function hitRectTestStraighEdge(
             (y = py + pdy * t) >= bt && y <= bb
         );
     };
-    let Dx = p1.x - p0.x;
-    let Dy = p1.y - p0.y;
+    const Dx = p1.x - p0.x;
+    const Dy = p1.y - p0.y;
     return (
         // Line intersects left boundary.
         intersect(L, p0.x, p0.y, Dx, Dy, T, B) ||

--- a/app/components/graph-editor/drawable-element.ts
+++ b/app/components/graph-editor/drawable-element.ts
@@ -120,7 +120,7 @@ export abstract class DrawableElement extends Drawable {
                 enumerable: true,
                 get: () => this._color,
                 set: (value: string) => {
-                    let old = this._color;
+                    const old = this._color;
                     if (this._color !== value) {
                         this._color = value;
                         this.onPropertyChanged("color", old);
@@ -131,7 +131,7 @@ export abstract class DrawableElement extends Drawable {
                 enumerable: true,
                 get: () => this._lines.join("\n"),
                 set: (value: string) => {
-                    let old = this.label;
+                    const old = this.label;
                     if (value !== this.label) {
                         if (value.trim() !== "")
                             this._lines = value.split("\n");
@@ -145,7 +145,7 @@ export abstract class DrawableElement extends Drawable {
                 enumerable: false,
                 get: () => this._state,
                 set: (value: DrawableStates) => {
-                    let old = this._state;
+                    const old = this._state;
                     if (this._state !== value) {
                         this._state = value;
                         this.onPropertyChanged("state", old);
@@ -166,7 +166,7 @@ export abstract class DrawableElement extends Drawable {
                 enumerable: false,
                 get: () => this._selected,
                 set: (value: boolean) => {
-                    let old = this._selected;
+                    const old = this._selected;
                     if (this._selected !== value) {
                         if (value)
                             this.graph.selectItems(this);

--- a/app/components/graph-editor/drawable-node.ts
+++ b/app/components/graph-editor/drawable-node.ts
@@ -30,7 +30,7 @@ import * as MathEx from "./math";
 
 
 /**
- * DrawableNode  
+ * DrawableNode
  *   Represents a node that is drawn on a graph editor canvas.
  */
 export class DrawableNode extends DrawableElement {
@@ -149,7 +149,7 @@ export class DrawableNode extends DrawableElement {
                             x: v.x - this._size.w / 2,
                             y: v.y - this._size.h / 2
                         };
-                        if (this._apts.filter(a => a.x === pt.x && a.y === pt.y).length == 0)
+                        if (this._apts.filter(a => a.x === pt.x && a.y === pt.y).length === 0)
                             this._apts.push(pt);
                     });
                 }
@@ -231,77 +231,77 @@ export class DrawableNode extends DrawableElement {
     private _pt: point;
 
     /**
-     * _shape  
+     * _shape
      *   The shape of the node.
      */
     private _shape: Shapes;
 
     /**
-     * _img  
+     * _img
      *   Path to the custom image.
      */
     private _img: string;
 
     /**
      * _apts
-     * 
+     *
      *   The collection of anchor points.
      */
     private _apts: point[];
 
     /**
-     * _borderColor  
+     * _borderColor
      *   The border color of the node.  Can be any valid `CSS` color string.
      */
     private _borderColor: string;
 
     /**
-     * _borderStyle  
+     * _borderStyle
      *   The line style of the border. Can be `solid`, `dotted`, or `dashed`.
      */
     private _borderStyle: LineStyles;
 
     /**
-     * _borderWidth  
+     * _borderWidth
      *   The line width of the border. Set to 0 to draw no border; value must be
      *   non-negative.
      */
     private _borderWidth: number;
 
     /**
-     * _size  
+     * _size
      *   The dimensions of the node.
      */
     private _size: size;
 
     /**
-     * _innerBound  
+     * _innerBound
      *   The inner dimensions of the node for hit detecting the edge creation
      *   region.
      */
     private _innerBound: size;
 
     /**
-     * _outerBound  
+     * _outerBound
      *   The outer dimensions of the noed for hit detecting the edge creation
      *   region.
      */
     private _outerBound: size;
 
     /**
-     * _incomingSet  
+     * _incomingSet
      *   The set of incoming edges.
      */
     private _incomingSet: Set<DrawableEdge>;
 
     /**
-     * _outgoingSet  
+     * _outgoingSet
      *   The set of outgoing edges.
      */
     private _outgoingSet: Set<DrawableEdge>;
 
     /**
-     * _apt  
+     * _apt
      *   The anchor point.
      */
     private _apt: point;
@@ -309,27 +309,27 @@ export class DrawableNode extends DrawableElement {
     // Public fields ///////////////////////////////////////////////////////////
 
     /**
-     * position  
+     * position
      *   Gets or sets the position of the node.
      */
     position: point;
 
     /**
-     * shape  
+     * shape
      *   Gets or sets the shape of the node.
      */
     shape: Shapes;
 
     /**
-     * image  
+     * image
      *   Gets or sets the path to a custom SVG image.
      */
     image: string;
 
     /**
-     * anchorPoints  
+     * anchorPoints
      *   Gets or sets the anchor points.
-     * 
+     *
      * <p>
      *   The location of each anchor point is in relation to the (0, 0)
      *   coordinate of the image file, or the top left corner of the bounding
@@ -339,61 +339,61 @@ export class DrawableNode extends DrawableElement {
     anchorPoints: point[];
 
     /**
-     * borderColor  
+     * borderColor
      *   Gets or sets the color of the node border.
      */
     borderColor: string;
 
     /**
-     * borderStyle  
+     * borderStyle
      *   Gets or sets the line style of the border.
      */
     borderStyle: LineStyles;
 
     /**
-     * borderWidth  
+     * borderWidth
      *   Gets or sets the line width of the border.
      */
     borderWidth: number;
 
     /**
-     * isHidden  
+     * isHidden
      *   Gets whether or not this node is hidden.
      */
     readonly isHidden: boolean;
 
     /**
-     * incomingEdges  
+     * incomingEdges
      *   Gets a set of the incoming edges.
      */
     readonly incomingEdges: Set<DrawableEdge>;
 
     /**
-     * outgoingEdges  
+     * outgoingEdges
      *   Gets a set of the outgoing edges.
      */
     readonly outgoingEdges: Set<DrawableEdge>;
 
     /**
-     * edges  
+     * edges
      *   Gets a set of the incoming and outgoing edges.
      */
     readonly edges: Set<DrawableEdge>;
 
     /**
-     * anchorPoint  
+     * anchorPoint
      *   Gets or sets the visible anchor point.
      */
     anchorPoint: point;
 
     /**
-     * isAnchorVisible  
+     * isAnchorVisible
      *   Gets whether or not the anchor point should be visible.
      */
     readonly isAnchorVisible: boolean;
 
     /**
-     * clearAnchor  
+     * clearAnchor
      *   Clears the anchor visibility.
      */
     clearAnchor() {
@@ -402,7 +402,7 @@ export class DrawableNode extends DrawableElement {
 
     /**
      * addEdge
-     * 
+     *
      *   Adds an edge to this node.
      */
     addEdge(e: DrawableEdge) {
@@ -415,7 +415,7 @@ export class DrawableNode extends DrawableElement {
     }
 
     /**
-     * removeEdge  
+     * removeEdge
      *   Removes an edge from this node.
      */
     removeEdge(e: DrawableEdge) {
@@ -426,7 +426,7 @@ export class DrawableNode extends DrawableElement {
     }
 
     /**
-     * update  
+     * update
      *   Updates the node geometry and draw logic.
      */
     update(g: GraphEditorCanvas) {
@@ -454,7 +454,7 @@ export class DrawableNode extends DrawableElement {
     }
 
     /**
-     * updateDraw  
+     * updateDraw
      *   Updates the draw logic of the node.
      */
     updateDraw(g: GraphEditorCanvas) {
@@ -508,7 +508,7 @@ export class DrawableNode extends DrawableElement {
                     g.drawImage(pt, IMAGES.get(this._img) !, sc);
                     break;
             }
-        }
+        };
         if (this._lines.length > 0) {
             ///////////////////////////
             // Labelled, With Anchor //
@@ -550,9 +550,9 @@ export class DrawableNode extends DrawableElement {
     }
 
     /**
-     * hitPoint  
+     * hitPoint
      *   Tests whether or not a point is within the hit threshold of the node.
-     * 
+     *
      * @returns
      *   An anchor point if the given point is within the threshold of the node;
      *   otherwise, null.
@@ -577,7 +577,7 @@ export class DrawableNode extends DrawableElement {
                 const dot = MathEx.dot(v, v);
                 if (dot < ib.w * ib.w / 4)
                     return this._pt;
-                if (apts.length == 0 && dot <= ob.w * ob.w / 4) {
+                if (apts.length === 0 && dot <= ob.w * ob.w / 4) {
                     const d = Math.sqrt(dot);
                     return this.getBoundaryPt({ x: v.x / d, y: v.y / d });
                 }
@@ -589,7 +589,7 @@ export class DrawableNode extends DrawableElement {
                 const ay = Math.abs(v.y);
                 if (ax < ib.w / 2 && ay < ib.h / 2)
                     return this._pt;
-                if (apts.length == 0 && ax <= ob.w / 2 && ay <= ob.h / 2) {
+                if (apts.length === 0 && ax <= ob.w / 2 && ay <= ob.h / 2) {
                     const d = MathEx.mag(v);
                     return this.getBoundaryPt({ x: v.x / d, y: v.y / d });
                 }
@@ -599,7 +599,7 @@ export class DrawableNode extends DrawableElement {
     }
 
     /**
-     * hitRect  
+     * hitRect
      *   Tests whether or not the node is captured by a rectangle.
      */
     hitRect(r: rect): boolean {
@@ -614,8 +614,8 @@ export class DrawableNode extends DrawableElement {
     }
 
     /**
-     * getNearestAnchor  
-     * 
+     * getNearestAnchor
+     *
      *   Gets the nearest anchor point or the origin of the node if there are no
      *   predefined anchor points.
      */
@@ -627,7 +627,7 @@ export class DrawableNode extends DrawableElement {
             let v = {
                 x: p.x - a.x,
                 y: p.y - a.y
-            }
+            };
             let dot = MathEx.dot(v, v);
             if (dot <= min) {
                 min = dot;
@@ -638,7 +638,7 @@ export class DrawableNode extends DrawableElement {
     }
 
     /**
-     * getBoundaryPt  
+     * getBoundaryPt
      *   Gets the vector in the direction of `u` that is on the boundary of a
      *   node based on its geometry.
      */
@@ -686,7 +686,7 @@ export class DrawableNode extends DrawableElement {
 
 
 /**
- * HiddenNode  
+ * HiddenNode
  *   Creates an invisible drawable node.
  */
 export class HiddenNode extends DrawableNode {

--- a/app/components/graph-editor/drawable-node.ts
+++ b/app/components/graph-editor/drawable-node.ts
@@ -17,6 +17,7 @@ import { DrawableGraph } from "./drawable-graph";
 import { DrawableElement } from "./drawable-element";
 import { DrawableEdge } from "./drawable-edge";
 import {
+    IMAGES,
     GraphEditorCanvas,
     LineStyles,
     makeRect,
@@ -33,18 +34,200 @@ import * as MathEx from "./math";
  *   Represents a node that is drawn on a graph editor canvas.
  */
 export class DrawableNode extends DrawableElement {
+    constructor(graph: DrawableGraph, like?: DrawableNode) {
+        super(graph);
+        Object.defineProperties(this, {
+            _pt: {
+                enumerable: false,
+                writable: true,
+                value: {
+                    x: (like ? like._pt.x + GRID_SPACING : NODE_PROPERTIES.position.x),
+                    y: (like ? like._pt.y + GRID_SPACING : NODE_PROPERTIES.position.y),
+                }
+            },
+            _shape: {
+                enumerable: false,
+                writable: true,
+                value: (like ? like._shape : NODE_PROPERTIES.shape as Shapes)
+            },
+            _img: {
+                enumerable: false,
+                writable: true,
+                // TODO:
+                // Remove this.
+                value: require('../../../plugins/and_gate.svg')
+            },
+            _borderColor: {
+                enumerable: false,
+                writable: true,
+                value: (like ? like._borderColor : NODE_PROPERTIES.borderColor)
+            },
+            _borderStyle: {
+                enumerable: false,
+                writable: true,
+                value: (like ? like._borderStyle : NODE_PROPERTIES.borderStyle as LineStyles)
+            },
+            _borderWidth: {
+                enumerable: false,
+                writable: true,
+                value: (like ? like._borderWidth : NODE_PROPERTIES.borderWidth)
+            },
+            _size: {
+                enumerable: false,
+                writable: true,
+                value: { h: 0, w: 0 }
+            },
+            _innerBound: {
+                enumerable: false,
+                writable: true,
+                value: { h: 0, w: 0 }
+            },
+            _outerBound: {
+                enumerable: false,
+                writable: true,
+                value: { h: 0, w: 0 }
+            },
+            _incomingSet: {
+                enumerable: false,
+                writable: false,
+                value: new Set<DrawableEdge>()
+            },
+            _outgoingSet: {
+                enumerable: false,
+                writable: false,
+                value: new Set<DrawableEdge>()
+            },
+            _apt: {
+                enumerable: false,
+                writable: true,
+                value: this._pt
+            },
+            position: {
+                enumerable: true,
+                get: () => this._pt,
+                set: (value: point) => {
+                    const old = this.position;
+                    if (this._pt.x !== value.x || this._pt.y !== value.y) {
+                        this._pt.x = value.x;
+                        this._pt.y = value.y;
+                        this.onPropertyChanged("position", old);
+                    }
+                }
+            },
+            shape: {
+                enumerable: true,
+                get: () => this._shape,
+                set: (value: Shapes) => {
+                    const old = this._shape;
+                    if (this._shape !== value) {
+                        this._shape = value;
+                        this.onPropertyChanged("shape", old);
+                    }
+                }
+            },
+            image: {
+                enumerable: true,
+                get: () => this._img,
+                set: (value: string) => {
+                    const old = this._img;
+                    if (this._img !== value) {
+                        this._img = value;
+                        this.onPropertyChanged("image", old);
+                    }
+                }
+            },
+            anchorPoints: {
+                enumerable: true,
+                writable: true,
+                value: (like ? like.anchorPoints : [])
+            },
+            borderColor: {
+                enumerable: true,
+                get: () => this._borderColor,
+                set: (value: string) => {
+                    const old = this._borderColor;
+                    if (this._borderColor !== value) {
+                        this._borderColor = value;
+                        this.onPropertyChanged("borderColor", old);
+                    }
+                }
+            },
+            borderStyle: {
+                enumerable: true,
+                get: () => this._borderStyle,
+                set: (value: LineStyles) => {
+                    const old = this._borderStyle;
+                    if (this._borderStyle !== value) {
+                        this._borderStyle = value;
+                        this.onPropertyChanged("borderStyle", old);
+                    }
+                }
+            },
+            borderWidth: {
+                enumerable: true,
+                get: () => this._borderWidth,
+                set: (value: number) => {
+                    const old = this._borderWidth;
+                    if (this._borderWidth !== value) {
+                        this._borderWidth = value;
+                        this.onPropertyChanged("borderWidth", old);
+                    }
+                }
+            },
+            isHidden: {
+                enumerable: false,
+                get: () => this instanceof HiddenNode
+            },
+            incomingEdges: {
+                enumerable: false,
+                get: () => new Set<DrawableEdge>([...this._incomingSet])
+            },
+            outgoingEdges: {
+                enumerable: false,
+                get: () => new Set<DrawableEdge>([...this._outgoingSet])
+            },
+            edges: {
+                enumerable: false,
+                get: () => new Set<DrawableEdge>([
+                    ...this._incomingSet,
+                    ...this._outgoingSet
+                ])
+            },
+            anchorPoint: {
+                enumerable: false,
+                get: () => this._apt,
+                set: (value: point) => this._apt = value
+            },
+            isAnchorVisible: {
+                enumerable: false,
+                get: () => this._apt !== this._pt
+            }
+        });
+        Object.seal(this);
+        this.color = (like ? like._color : NODE_PROPERTIES.color);
+        this.label = (like ? like.label : NODE_PROPERTIES.label);
+        this.clearAnchor();
+    }
+
+    // Private fields //////////////////////////////////////////////////////////
 
     /**
-     * _position  
+     * _pt
      *   The coordinates of the center of the node.
      */
-    private _position: point;
+    private _pt: point;
 
     /**
      * _shape  
      *   The shape of the node.
      */
     private _shape: Shapes;
+
+    /**
+     * _img  
+     *   Path to the custom image.
+     */
+    private _img: string;
 
     /**
      * _borderColor  
@@ -103,160 +286,7 @@ export class DrawableNode extends DrawableElement {
      */
     private _apt: point;
 
-    /**
-     * constructor
-     */
-    constructor(graph: DrawableGraph, like?: DrawableNode) {
-        super(graph);
-        Object.defineProperties(this, {
-            _position: {
-                enumerable: false,
-                writable: true,
-                value: {
-                    x: (like ? like._position.x + GRID_SPACING : NODE_PROPERTIES.position.x),
-                    y: (like ? like._position.y + GRID_SPACING : NODE_PROPERTIES.position.y),
-                }
-            },
-            _shape: {
-                enumerable: false,
-                writable: true,
-                value: (like ? like._shape : NODE_PROPERTIES.shape as Shapes)
-            },
-            _borderColor: {
-                enumerable: false,
-                writable: true,
-                value: (like ? like._borderColor : NODE_PROPERTIES.borderColor)
-            },
-            _borderStyle: {
-                enumerable: false,
-                writable: true,
-                value: (like ? like._borderStyle : NODE_PROPERTIES.borderStyle as LineStyles)
-            },
-            _borderWidth: {
-                enumerable: false,
-                writable: true,
-                value: (like ? like._borderWidth : NODE_PROPERTIES.borderWidth)
-            },
-            _size: {
-                enumerable: false,
-                writable: true,
-                value: { h: 0, w: 0 }
-            },
-            _innerBound: {
-                enumerable: false,
-                writable: true,
-                value: { h: 0, w: 0 }
-            },
-            _outerBound: {
-                enumerable: false,
-                writable: true,
-                value: { h: 0, w: 0 }
-            },
-            _incomingSet: {
-                enumerable: false,
-                writable: false,
-                value: new Set<DrawableEdge>()
-            },
-            _outgoingSet: {
-                enumerable: false,
-                writable: false,
-                value: new Set<DrawableEdge>()
-            },
-            _apt: {
-                enumerable: false,
-                writable: true,
-                value: this._position
-            },
-            position: {
-                enumerable: true,
-                get: () => this._position,
-                set: (value: point) => {
-                    let old = this.position;
-                    if (this._position.x !== value.x || this._position.y !== value.y) {
-                        this._position.x = value.x;
-                        this._position.y = value.y;
-                        this.onPropertyChanged("position", old);
-                    }
-                }
-            },
-            shape: {
-                enumerable: true,
-                get: () => this._shape,
-                set: (value: Shapes) => {
-                    let old = this._shape;
-                    if (this._shape !== value) {
-                        this._shape = value;
-                        this.onPropertyChanged("shape", old);
-                    }
-                }
-            },
-            borderColor: {
-                enumerable: true,
-                get: () => this._borderColor,
-                set: (value: string) => {
-                    let old = this._borderColor;
-                    if (this._borderColor !== value) {
-                        this._borderColor = value;
-                        this.onPropertyChanged("borderColor", old);
-                    }
-                }
-            },
-            borderStyle: {
-                enumerable: true,
-                get: () => this._borderStyle,
-                set: (value: LineStyles) => {
-                    let old = this._borderStyle;
-                    if (this._borderStyle !== value) {
-                        this._borderStyle = value;
-                        this.onPropertyChanged("borderStyle", old);
-                    }
-                }
-            },
-            borderWidth: {
-                enumerable: true,
-                get: () => this._borderWidth,
-                set: (value: number) => {
-                    let old = this._borderWidth;
-                    if (this._borderWidth !== value) {
-                        this._borderWidth = value;
-                        this.onPropertyChanged("borderWidth", old);
-                    }
-                }
-            },
-            isHidden: {
-                enumerable: false,
-                get: () => this instanceof HiddenNode
-            },
-            incomingEdges: {
-                enumerable: false,
-                get: () => new Set<DrawableEdge>([...this._incomingSet])
-            },
-            outgoingEdges: {
-                enumerable: false,
-                get: () => new Set<DrawableEdge>([...this._outgoingSet])
-            },
-            edges: {
-                enumerable: false,
-                get: () => new Set<DrawableEdge>([
-                    ...this._incomingSet,
-                    ...this._outgoingSet
-                ])
-            },
-            anchorPoint: {
-                enumerable: false,
-                get: () => this._apt,
-                set: (value: point) => this._apt = value
-            },
-            isAnchorVisible: {
-                enumerable: false,
-                get: () => this._apt !== this._position
-            }
-        });
-        Object.seal(this);
-        this.color = (like ? like._color : NODE_PROPERTIES.color);
-        this.label = (like ? like.label : NODE_PROPERTIES.label);
-        this.clearAnchor();
-    }
+    // Public fields ///////////////////////////////////////////////////////////
 
     /**
      * position  
@@ -269,6 +299,24 @@ export class DrawableNode extends DrawableElement {
      *   Gets or sets the shape of the node.
      */
     shape: Shapes;
+
+    /**
+     * image  
+     *   Gets or sets the path to a custom SVG image.
+     */
+    image: string;
+
+    /**
+     * anchorPoints  
+     *   Gets or sets the anchor points.
+     * 
+     * <p>
+     *   The location of each anchor point is in relation to the (0, 0)
+     *   coordinate of the image file, or the top left corner of the bounding
+     *   rectangle of the selected shape.
+     * </p>
+     */
+    anchorPoints: point[];
 
     /**
      * borderColor  
@@ -329,7 +377,7 @@ export class DrawableNode extends DrawableElement {
      *   Clears the anchor visibility.
      */
     clearAnchor() {
-        this.anchorPoint = this._position;
+        this.anchorPoint = this._pt;
     }
 
     /**
@@ -337,7 +385,7 @@ export class DrawableNode extends DrawableElement {
      *   Adds an edge to this node.
      */
     addEdge(e: DrawableEdge) {
-        let old = this.edges;
+        const old = this.edges;
         if (e.source === this)
             this._outgoingSet.add(e);
         else if (e.destination === this)
@@ -350,7 +398,7 @@ export class DrawableNode extends DrawableElement {
      *   Removes an edge from this node.
      */
     removeEdge(e: DrawableEdge) {
-        let old = this.edges;
+        const old = this.edges;
         this._incomingSet.delete(e);
         this._outgoingSet.delete(e);
         this.onPropertyChanged("edges", old);
@@ -362,18 +410,25 @@ export class DrawableNode extends DrawableElement {
      */
     update(g: GraphEditorCanvas) {
         this.updateTextSize(g);
-        let s = (GRID_SPACING > this._textSize.h + 1.5 * FONT_SIZE ?
-            GRID_SPACING : this._textSize.h + 1.5 * FONT_SIZE);
-        s = (s < this._textSize.w + FONT_SIZE ?
-            this._textSize.w + FONT_SIZE : s);
-        this._size.h = s;
-        this._size.w = s;
-        this._innerBound.h = s - 2 * NODE_THRESHOLD_IN;
-        this._innerBound.w = this._innerBound.h;
-        this._outerBound.h = s + 2 * NODE_THRESHOLD_OUT;
-        this._outerBound.w = this._outerBound.h;
+        if (this._shape === "image") {
+            const img = IMAGES.get(this._img);
+            this._size.h = img!.height;
+            this._size.w = img!.width;
+        }
+        else {
+            let s = (GRID_SPACING > this._textSize.h + 1.5 * FONT_SIZE ?
+                GRID_SPACING : this._textSize.h + 1.5 * FONT_SIZE);
+            s = (s < this._textSize.w + FONT_SIZE ?
+                this._textSize.w + FONT_SIZE : s);
+            this._size.h = s;
+            this._size.w = s;
+        }
+        this._innerBound.h = this._size.h - 2 * NODE_THRESHOLD_IN;
+        this._innerBound.w = this._size.w - 2 * NODE_THRESHOLD_IN;
+        this._outerBound.h = this._size.h + 2 * NODE_THRESHOLD_OUT;
+        this._outerBound.w = this._size.w + 2 * NODE_THRESHOLD_OUT;
         this.updateDraw(g);
-        for (let e of this.edges)
+        for (const e of this.edges)
             e.update(g);
     }
 
@@ -382,18 +437,25 @@ export class DrawableNode extends DrawableElement {
      *   Updates the draw logic of the node.
      */
     updateDraw(g: GraphEditorCanvas) {
-        let pt = this._position;
-        let sz = this._size;
-        let bc = this._borderColor;
-        let bs = this._borderStyle;
-        let bw = this._borderWidth;
-        let cl = this._color;
+        let pt = this._pt;
+        const sz = this._size;
+        const bc = this._borderColor;
+        const bs = this._borderStyle;
+        const bw = this._borderWidth;
+        const cl = this._color;
         let sc = (this.isDragging ? NODE_DRAG_SHADOW_COLOR : (this.isHovered ? SELECTION_COLOR : undefined));
+        if (this._shape === "image") {
+            pt = {
+                x: pt.x - sz.w / 2,
+                y: pt.y - sz.h / 2
+            }
+        }
         /////////////////////////
         // Set selected shadow //
         /////////////////////////
         if (this.isSelected) {
-            let shadow = sc;
+            const shadow = sc;
+            const offsets = [-2, -2, 0, -2, 2, -2, -2, 0, 2, 0, -2, 2, 0, 2, 2, 2];
             this._drawSelectionShadow = () => {
                 switch (this._shape) {
                     case "circle":
@@ -402,9 +464,16 @@ export class DrawableNode extends DrawableElement {
                     case "square":
                         g.drawSquare(pt, sz.w + bw + 4, "solid", bw, SELECTION_COLOR, SELECTION_COLOR, shadow);
                         break;
+                    case "image":
+                        for (let i = 0; i < offsets.length; i += 2) {
+                            const opt = { x: pt.x + offsets[i], y: pt.y + offsets[i + 1] };
+                            g.drawImage(opt, IMAGES.get(this._img) !);
+                        }
+                        break;
                 }
             };
-            sc = undefined;
+            if (this._shape !== "image")
+                sc = undefined;
         }
         else {
             this._drawSelectionShadow = () => { };
@@ -412,13 +481,16 @@ export class DrawableNode extends DrawableElement {
         //////////////
         // Set node //
         //////////////
-        let shapeThunk = () => {
+        const shapeThunk = () => {
             switch (this._shape) {
                 case "circle":
                     g.drawCircle(pt, sz.w / 2, bs, bw, bc, cl, sc);
                     break;
                 case "square":
                     g.drawSquare(pt, sz.w, bs, bw, bc, cl, sc);
+                    break;
+                case "image":
+                    g.drawImage(pt, IMAGES.get(this._img) !, sc);
                     break;
             }
         }
@@ -471,42 +543,57 @@ export class DrawableNode extends DrawableElement {
      *   otherwise, null.
      */
     hitPoint(pt: point): point | null {
-        let posn = this._position;
+        let apt = this._pt;
+        const posn = { x: apt.x, y: apt.y };
+        const size = this._size;
+        const v = { x: pt.x - posn.x, y: pt.y - posn.y };
+        const ib = this._innerBound;
+        const ob = this._outerBound;
+        const apts = this.anchorPoints;
+        if (apts.length > 0) {
+            let d = NODE_THRESHOLD_OUT - NODE_THRESHOLD_IN;
+            d = d * d / 4;
+            let min = d;
+            for (const a of apts) {
+                let p = {
+                    x: posn.x - size.w / 2 + a.x,
+                    y: posn.y - size.h / 2 + a.y
+                }
+                let u = {
+                    x: pt.x - p.x,
+                    y: pt.y - p.y
+                }
+                let dot = MathEx.dot(u, u);
+                if (dot <= min) {
+                    min = dot;
+                    apt = p;
+                }
+            }
+            if (apt !== this._pt)
+                return apt;
+        }
         switch (this._shape) {
-            case "circle":
-                let r = this._outerBound.w / 2;
-                let v = { x: pt.x - posn.x, y: pt.y - posn.y };
-                let d = MathEx.mag(v);
-                if (d <= r) {
-                    r = this._innerBound.w / 2;
-                    let anchor: point = posn;
-                    if (d >= r)
-                        anchor = this.getBoundaryPt({ x: v.x / d, y: v.y / d });
-                    return anchor;
+            case "circle": {
+                const dot = MathEx.dot(v, v);
+                if (dot < ib.w * ib.w / 4)
+                    return apt;
+                if (apts.length == 0 && dot <= ob.w * ob.w / 4) {
+                    const d = Math.sqrt(dot);
+                    return this.getBoundaryPt({ x: v.x / d, y: v.y / d });
                 }
+            } break;
 
-            case "square":
-                let hs = this._outerBound.w / 2;
-                let rect = makeRect(
-                    { x: posn.x - hs, y: posn.y - hs },
-                    { x: posn.x + hs, y: posn.y + hs }
-                );
-                if ((pt.x >= rect.x && pt.x <= rect.x + rect.w) &&
-                    (pt.y >= rect.y && pt.y <= rect.y + rect.w)) {
-                    let v = { x: pt.x - posn.x, y: pt.y - posn.y };
-                    let d = MathEx.mag(v);
-                    hs = this._innerBound.w / 2;
-                    rect = makeRect(
-                        { x: posn.x - hs, y: posn.y - hs },
-                        { x: posn.x + hs, y: posn.y + hs }
-                    );
-                    let anchor: point = posn;
-                    if ((pt.x <= rect.x || pt.x >= rect.x + rect.w) ||
-                        (pt.y <= rect.y || pt.y >= rect.y + rect.w)) {
-                        anchor = this.getBoundaryPt({ x: v.x / d, y: v.y / d });
-                    }
-                    return anchor;
+            case "image":
+            case "square": {
+                const ax = Math.abs(v.x);
+                const ay = Math.abs(v.y);
+                if (ax < ib.w / 2 && ay < ib.h / 2)
+                    return apt;
+                if (apts.length == 0 && ax <= ob.w / 2 && ay <= ob.h / 2) {
+                    const d = MathEx.mag(v);
+                    return this.getBoundaryPt({ x: v.x / d, y: v.y / d });
                 }
+            } break;
         }
         return null;
     }
@@ -520,8 +607,8 @@ export class DrawableNode extends DrawableElement {
         const R = r.x + r.w;
         const T = r.y;
         const B = r.y + r.h;
-        let posn = this._position;
-        let D = this._size.w / 2;
+        const posn = this._pt;
+        const D = this._size.w / 2;
         return (posn.x >= L - D && posn.x <= R + D &&
             posn.y >= T - D && posn.y <= B + D);
     }
@@ -532,43 +619,42 @@ export class DrawableNode extends DrawableElement {
      *   node based on its geometry.
      */
     getBoundaryPt(u: point) {
-        let v: point = { x: 0, y: 0 };
-        let border = this._borderWidth / 2;
+        const v: point = { x: 0, y: 0 };
+        const sz = this._size;
+        const border = this._borderWidth / 2;
 
         switch (this._shape) {
             // The boundary of a circle is just its radius plus half its border
             // width.
-            case "circle":
-                let r = this._size.h / 2;
-                v.x = u.x * r + border;
-                v.y = u.y * r + border;
-                break;
+            case "circle": {
+                const r = sz.h / 2 + border;
+                v.x = u.x * r;
+                v.y = u.y * r;
+            } break;
 
-            // The boundary of a square depends on the direction of u.
-            case "square":
-                let up = {
+            // The boundary of a rectangle depends on the direction of u.
+            case "image":
+            case "square": {
+                const up = {
                     x: (u.x < 0 ? -u.x : u.x),
                     y: (u.y < 0 ? -u.y : u.y)
                 };
-                let s = this._size.h / 2;
-                if (up.x < up.y) {
-                    let ratio = up.x / up.y;
-                    let b = s / up.y;
-                    let a = ratio * up.x;
-                    s = MathEx.mag({ x: a, y: b });
+                const h = sz.h / 2 + border;
+                const w = sz.w / 2 + border;
+                v.x = (h * up.x + up.x * up.y) / up.y;
+                if (v.x > w) {
+                    v.x = w;
+                    v.y = (w * up.y + up.y * up.x) / up.x;
                 }
-                else {
-                    let ratio = up.y / up.x;
-                    let a = s / up.x;
-                    let b = ratio * up.y;
-                    s = MathEx.mag({ x: a, y: b });
-                }
-                v.x = u.x * s + border;
-                v.y = u.y * s + border;
-                break;
+                else
+                    v.y = h;
+                const d = MathEx.mag(v);
+                v.x = u.x * d;
+                v.y = u.y * d;
+            } break;
         }
-        v.x += this._position.x;
-        v.y += this._position.y;
+        v.x += this._pt.x;
+        v.y += this._pt.y;
         return v;
     }
 

--- a/app/components/graph-editor/graph-editor-canvas.ts
+++ b/app/components/graph-editor/graph-editor-canvas.ts
@@ -52,7 +52,7 @@ export type CompositeOperations =
 /**
  * LineStyles
  */
-export type LineStyles = "solid" | "dotted" | "dashed";
+export type LineStyles = "solid" | "dotted" | "dashed" | "double";
 
 /**
  * Shapes

--- a/app/components/graph-editor/graph-editor-canvas.ts
+++ b/app/components/graph-editor/graph-editor-canvas.ts
@@ -55,10 +55,7 @@ export type CompositeOperations =
 export type LineStyles = "solid" | "dotted" | "dashed";
 
 /**
- * Shapes  
- * 
- * TODO:  
- * -For now this only supports circles and squares.
+ * Shapes
  */
 export type Shapes = "circle" | "square" | "image";
 
@@ -100,7 +97,7 @@ export const IMAGES = new Map<string, HTMLImageElement>();
  */
 export class GraphEditorCanvas {
     constructor(private g: CanvasRenderingContext2D) {
-        // These probably don't do anything.
+        // These probably do nothing.
         this.g.mozImageSmoothingEnabled = true;
         this.g.msImageSmoothingEnabled = true;
         this.g.oImageSmoothingEnabled = true;
@@ -326,7 +323,11 @@ export class GraphEditorCanvas {
             this.shadowBlur = 20;
             this.g.shadowColor = shadowColor;
         }
-        this.g.drawImage(img, p.x, p.y);
+        this.g.drawImage(
+            img,
+            this._origin.x + p.x - img.width / 2,
+            this._origin.y + p.y - img.height / 2
+        );
         this.shadowBlur = 0;
     }
 

--- a/app/components/graph-editor/graph-editor-canvas.ts
+++ b/app/components/graph-editor/graph-editor-canvas.ts
@@ -8,7 +8,7 @@ import * as MathEx from "./math";
 
 
 /**
- * AA_SCALE  
+ * AA_SCALE
  *   Anti-aliasing scale.
  */
 const AA_SCALE: number = 2;
@@ -18,7 +18,7 @@ const AA_SCALE: number = 2;
 
 
 /**
- * CompositeOperations  
+ * CompositeOperations
  *   @see https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation
  */
 export type CompositeOperations =
@@ -60,19 +60,19 @@ export type LineStyles = "solid" | "dotted" | "dashed";
 export type Shapes = "circle" | "square" | "image";
 
 /**
- * point  
+ * point
  *   Represents a coordinate.
  */
 export type point = { x: number, y: number };
 
 /**
- * size  
+ * size
  *   Represents rectangle dimensions.
  */
 export type size = { h: number, w: number };
 
 /**
- * rect  
+ * rect
  *   Represents a rectangle with the top-left coordinate and height and width.
  */
 export type rect = point & size;
@@ -82,7 +82,7 @@ export type rect = point & size;
 
 
 /**
- * IMAGES  
+ * IMAGES
  *   Contains a map of cached images.
  */
 export const IMAGES = new Map<string, HTMLImageElement>();
@@ -92,7 +92,7 @@ export const IMAGES = new Map<string, HTMLImageElement>();
 
 
 /**
- * GraphEditorCanvas  
+ * GraphEditorCanvas
  *   Object that handles all of the drawing logic of the graph editor.
  */
 export class GraphEditorCanvas {
@@ -108,13 +108,13 @@ export class GraphEditorCanvas {
 
 
     /**
-     * _scale  
+     * _scale
      *   Scaling factor of the canvas.
      */
     private _scale: number = AA_SCALE;
 
     /**
-     * _origin  
+     * _origin
      *   The coordinates of the canvas origin.
      */
     private _origin: point = { x: 0, y: 0 };
@@ -124,7 +124,7 @@ export class GraphEditorCanvas {
 
 
     /**
-     * tracePath  
+     * tracePath
      *   Traces line segments from point to point of the given points.
      */
     tracePath(...pts: point[]) {
@@ -134,7 +134,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * traceQuadratic  
+     * traceQuadratic
      *   Traces a quadratic Bezier curve.
      */
     traceQuadratic(start: point, end: point, control: point) {
@@ -146,7 +146,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * traceCubic  
+     * traceCubic
      *   Traces a cubic Bezier curve.
      */
     traceCubic(start: point, end: point, control1: point, control2: point) {
@@ -159,7 +159,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * traceRect  
+     * traceRect
      *   Traces a rectangle.
      */
     traceRect(rect: rect) {
@@ -174,7 +174,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * traceCircle  
+     * traceCircle
      *   Traces a circle.
      */
     traceCircle(origin: point, radius: number) {
@@ -187,9 +187,9 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * traceArrow  
+     * traceArrow
      *   Traces an arrow towards the destination point.
-     * 
+     *
      *   The arrow is traced by computing the unit vector from the given source
      *   and destination points and rotating, scaling, and translating the unit
      *   vector before tracing the left and right sides of the arrow.
@@ -226,7 +226,7 @@ export class GraphEditorCanvas {
 
 
     /**
-     * clear  
+     * clear
      *   Clears the canvas.
      */
     clear(bgColor?: string): void {
@@ -241,7 +241,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * drawSelectionBox  
+     * drawSelectionBox
      *   Draws the selection box.
      */
     drawSelectionBox(rect: rect): void {
@@ -257,7 +257,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * drawCircle  
+     * drawCircle
      *   Draws a circle.
      */
     drawCircle(
@@ -286,7 +286,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * drawSquare  
+     * drawSquare
      *   Draws a square.
      */
     drawSquare(
@@ -315,7 +315,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * drawImage  
+     * drawImage
      *   Draws an image.
      */
     drawImage(p: point, img: HTMLImageElement, shadowColor?: string) {
@@ -332,7 +332,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * drawGrid  
+     * drawGrid
      *   Draws the editor grid.
      */
     drawGrid() {
@@ -362,7 +362,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * drawGridLines  
+     * drawGridLines
      *   Draws a bunch of evenly-spaced grid lines.
      */
     private drawGridLines(o: point, h: number, w: number) {
@@ -381,7 +381,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * drawText  
+     * drawText
      *   Draws text.
      */
     drawText(
@@ -421,7 +421,7 @@ export class GraphEditorCanvas {
 
 
     /**
-     * size  
+     * size
      *   Gets or sets the size dimensions of the canvas.
      */
     get size() {
@@ -449,7 +449,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * scale  
+     * scale
      *   Gets or sets the canvas scaling factor.
      */
     get scale(): number {
@@ -464,7 +464,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * lineStyle  
+     * lineStyle
      *   Sets the line style of the rendering context.
      */
     set lineStyle(value: { style: string, dotSize?: number }) {
@@ -484,7 +484,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * shadowBlur  
+     * shadowBlur
      *   Sets the shadow blur range.
      */
     set shadowBlur(value: number) {
@@ -492,7 +492,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * shadowColor  
+     * shadowColor
      *   Sets the shadow color.
      */
     set shadowColor(value: string) {
@@ -500,7 +500,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * globalAlpha  
+     * globalAlpha
      *   Sets the global alpha channel.
      */
     set globalAlpha(value: number) {
@@ -512,7 +512,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * strokeStyle  
+     * strokeStyle
      *   Sets the stroke color.
      */
     set strokeStyle(value: string) {
@@ -520,7 +520,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * fillStyle  
+     * fillStyle
      *   Sets the fill color.
      */
     set fillStyle(value: string) {
@@ -528,7 +528,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * lineWidth  
+     * lineWidth
      *   Sets the line width.
      */
     set lineWidth(value: number) {
@@ -536,7 +536,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * getTextWidth  
+     * getTextWidth
      *   Gets the width of a string.
      */
     getTextWidth(text: string) {
@@ -545,7 +545,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * getPt  
+     * getPt
      *   Gets the canvas coordinates from a DOM event.
      */
     getPt(pt: point): point {
@@ -562,7 +562,7 @@ export class GraphEditorCanvas {
 
 
     /**
-     * beginPath  
+     * beginPath
      *   Starts tracing a path.
      */
     beginPath() {
@@ -570,7 +570,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * stroke  
+     * stroke
      *   Strokes a path.
      */
     stroke() {
@@ -578,7 +578,7 @@ export class GraphEditorCanvas {
     }
 
     /**
-     * fill  
+     * fill
      *   Fills a path.
      */
     fill() {
@@ -592,7 +592,7 @@ export class GraphEditorCanvas {
 
 
 /**
- * makeRect  
+ * makeRect
  *   Makes a rectangle object with the bottom-left corner and height and width
  *   using the given opposing corner points.
  */

--- a/app/components/graph-editor/graph-editor-canvas.ts
+++ b/app/components/graph-editor/graph-editor-canvas.ts
@@ -18,6 +18,38 @@ const AA_SCALE: number = 2;
 
 
 /**
+ * CompositeOperations  
+ *   @see https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation
+ */
+export type CompositeOperations =
+    "source-over" |
+    "source-in" |
+    "source-out" |
+    "source-atop" |
+    "destination-over" |
+    "destination-in" |
+    "destination-out" |
+    "destination-atop" |
+    "lighter" |
+    "copy" |
+    "xor" |
+    "multiply" |
+    "screen" |
+    "overlay" |
+    "darken" |
+    "lighten" |
+    "color-dodge" |
+    "color-burn" |
+    "hard-light" |
+    "soft-light" |
+    "difference" |
+    "exclusion" |
+    "hue" |
+    "saturation" |
+    "color" |
+    "luminosity";
+
+/**
  * LineStyles
  */
 export type LineStyles = "solid" | "dotted" | "dashed";
@@ -28,7 +60,7 @@ export type LineStyles = "solid" | "dotted" | "dashed";
  * TODO:  
  * -For now this only supports circles and squares.
  */
-export type Shapes = "circle" | "square";
+export type Shapes = "circle" | "square" | "image";
 
 /**
  * point  
@@ -47,6 +79,19 @@ export type size = { h: number, w: number };
  *   Represents a rectangle with the top-left coordinate and height and width.
  */
 export type rect = point & size;
+
+
+// Cached images ///////////////////////////////////////////////////////////////
+
+
+/**
+ * IMAGES  
+ *   Contains a map of cached images.
+ */
+export const IMAGES = new Map<string, HTMLImageElement>();
+
+
+// GraphEditorCanvas ///////////////////////////////////////////////////////////
 
 
 /**
@@ -157,12 +202,12 @@ export class GraphEditorCanvas {
         dst: point
     ): void {
         // Get the unit vector from the source point to the destination point.
-        let v: point = {
+        const v: point = {
             x: dst.x - src.x,
             y: dst.y - src.y
         };
-        let d = MathEx.mag(v);
-        let u = { x: v.x / d, y: v.y / d };
+        const d = MathEx.mag(v);
+        const u = { x: v.x / d, y: v.y / d };
 
         // Trace arrow.
         this.tracePath(
@@ -188,7 +233,7 @@ export class GraphEditorCanvas {
      *   Clears the canvas.
      */
     clear(bgColor?: string): void {
-        let canvas = this.g.canvas;
+        const canvas = this.g.canvas;
         if (bgColor) {
             this.g.fillStyle = bgColor;
             this.g.fillRect(0, 0, canvas.width / this._scale, canvas.height / this._scale);
@@ -273,15 +318,28 @@ export class GraphEditorCanvas {
     }
 
     /**
+     * drawImage  
+     *   Draws an image.
+     */
+    drawImage(p: point, img: HTMLImageElement, shadowColor?: string) {
+        if (shadowColor) {
+            this.shadowBlur = 20;
+            this.g.shadowColor = shadowColor;
+        }
+        this.g.drawImage(img, p.x, p.y);
+        this.shadowBlur = 0;
+    }
+
+    /**
      * drawGrid  
      *   Draws the editor grid.
      */
     drawGrid() {
 
-        let w = this.g.canvas.width / this._scale;
-        let h = this.g.canvas.height / this._scale;
+        const w = this.g.canvas.width / this._scale;
+        const h = this.g.canvas.height / this._scale;
 
-        let o = {
+        const o = {
             x: this.origin.x % DEFAULT.GRID_SPACING - DEFAULT.GRID_SPACING,
             y: this.origin.y % DEFAULT.GRID_SPACING - DEFAULT.GRID_SPACING
         };
@@ -333,7 +391,7 @@ export class GraphEditorCanvas {
         borderWidth?: number,
         borderColor?: string
     ) {
-        let x = p.x + this.origin.x;
+        const x = p.x + this.origin.x;
         let y = p.y + this.origin.y - (height - 1.5 * DEFAULT.FONT_SIZE) / 2;
         this.g.font = DEFAULT.FONT_SIZE + "pt " + DEFAULT.FONT_FAMILY;
         this.g.textAlign = "center";
@@ -360,12 +418,13 @@ export class GraphEditorCanvas {
 
     // Get and Set methods /////////////////////////////////////////////////////
 
+
     /**
      * size  
      *   Gets or sets the size dimensions of the canvas.
      */
     get size() {
-        let el = this.g.canvas;
+        const el = this.g.canvas;
         return {
             h: el.height / AA_SCALE,
             w: el.width / AA_SCALE
@@ -373,7 +432,7 @@ export class GraphEditorCanvas {
     }
 
     set size(value: { h: number, w: number }) {
-        let el = this.g.canvas;
+        const el = this.g.canvas;
         el.height = value.h * AA_SCALE;
         el.width = value.w * AA_SCALE;
         this.scale = this.scale;
@@ -447,6 +506,10 @@ export class GraphEditorCanvas {
         this.g.globalAlpha = value;
     }
 
+    set globalCompositeOperation(value: CompositeOperations) {
+        this.g.globalCompositeOperation = value;
+    }
+
     /**
      * strokeStyle  
      *   Sets the stroke color.
@@ -485,8 +548,8 @@ export class GraphEditorCanvas {
      *   Gets the canvas coordinates from a DOM event.
      */
     getPt(pt: point): point {
-        let canvas = this.g.canvas;
-        let r = canvas.getBoundingClientRect();
+        const canvas = this.g.canvas;
+        const r = canvas.getBoundingClientRect();
         return {
             x: (pt.x - r.left) / (r.right - r.left) * canvas.width / this._scale - this.origin.x,
             y: (pt.y - r.top) / (r.bottom - r.top) * canvas.height / this._scale - this.origin.y

--- a/app/components/graph-editor/graph-editor.component.ts
+++ b/app/components/graph-editor/graph-editor.component.ts
@@ -71,7 +71,7 @@ type callback = () => void;
     ]
 })
 /**
- * GraphEditorComponent  
+ * GraphEditorComponent
  *   Angular2 component that provides a canvas for drawing nodes and edges.
  */
 export class GraphEditorComponent implements AfterViewInit {
@@ -85,81 +85,81 @@ export class GraphEditorComponent implements AfterViewInit {
     private hiddenInputElementRef: ElementRef;
 
     /**
-     * canvasElementRef  
+     * canvasElementRef
      *   Reference to the canvas child element.
      */
     @ViewChild("sinapGraphEditorCanvas")
     private canvasElementRef: ElementRef;
 
     /**
-     * canvas  
+     * canvas
      *   The graph editor canvas.
      */
     private canvas: GraphEditorCanvas;
 
     /**
-     * graph  
+     * graph
      *   The graph object.
      */
     private graph: DrawableGraph;
 
     /**
-     * oldGraph  
+     * oldGraph
      *   The previous graph for unhooking events.
      */
     private oldGraph: DrawableGraph | null;
 
     /**
-     * panPt  
+     * panPt
      *   The previous pt from panning the canvas.
      */
     private panPt: pt | null
     = null;
 
     /**
-     * downEvt  
+     * downEvt
      *   The previous down event payload.
      */
     private downEvt: MouseEvent | null
     = null;
 
     /**
-     * stickyTimeout  
+     * stickyTimeout
      *   Timer reference for the sticky delay.
      */
     private stickyTimeout: NodeJS.Timer | num | null
     = null;
 
     /**
-     * dragObect  
+     * dragObect
      *   The node being dragged by the cursor.
      */
     private dragObject: DrawableNode | null
     = null;
 
     /**
-     * hoverObject  
+     * hoverObject
      *   The graph component over which the cursor is hovering.
      */
     private hoverObject: DrawableElement | null
     = null;
 
     /**
-     * moveEdge  
+     * moveEdge
      *   The edge to be replaced once the new edge has been created.
      */
     private moveEdge: DrawableEdge | null
     = null;
 
     /**
-     * drawList  
+     * drawList
      *   Maintains the draw order of drawable elements.
      */
     private drawList: DrawableElement[]
     = [];
 
     /**
-     * redrawDelegate  
+     * redrawDelegate
      *   For suspending and resuming draw calls.
      */
     private redrawDelegate: callback
@@ -176,7 +176,7 @@ export class GraphEditorComponent implements AfterViewInit {
 
 
     /**
-     * setGraph  
+     * setGraph
      *   Input property for the graph.
      */
     @Input("graph")
@@ -209,7 +209,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * suspendRedraw  
+     * suspendRedraw
      *   Suspends updates to the canvas.
      */
     suspendRedraw() {
@@ -217,7 +217,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * resumeRedraw  
+     * resumeRedraw
      *   Resumes updates to the canvas and forces a redraw.
      */
     resumeRedraw() {
@@ -241,13 +241,13 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * dragNode  
+     * dragNode
      *   Sets the node being dragged by the cursor.
-     * 
+     *
      * Note:
      * The intent of this function is to be able to set the drag node from the
      * components panel.
-     * 
+     *
      * TODO:
      * Maybe we can use the standard drop event for this instead.
      */
@@ -260,7 +260,7 @@ export class GraphEditorComponent implements AfterViewInit {
     // }
 
     /**
-     * scale  
+     * scale
      *   Sets the scaling factor of the canvas.
      */
     set scale(value: num) {
@@ -269,7 +269,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * origin  
+     * origin
      *   Sets the origin pt of the canvas.
      */
     set origin(value: pt) {
@@ -282,7 +282,7 @@ export class GraphEditorComponent implements AfterViewInit {
 
 
     /**
-     * ngAfterViewInit  
+     * ngAfterViewInit
      *   Gets the canvas rendering context and resizes the canvas element.
      */
     ngAfterViewInit() {
@@ -293,7 +293,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * resize  
+     * resize
      *   Resizes the canvas.
      */
     resize(): void {
@@ -301,7 +301,7 @@ export class GraphEditorComponent implements AfterViewInit {
         const pel = (el.parentNode as HTMLElement);
         const h = pel.offsetHeight;
         const w = pel.offsetWidth;
-        if (this.canvas.size.h != h || this.canvas.size.w != w) {
+        if (this.canvas.size.h !== h || this.canvas.size.w !== w) {
             this.canvas.size = { h: h, w: w };
             this.redraw();
         }
@@ -316,7 +316,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * redraw  
+     * redraw
      *   Redraws the graph.
      */
     get redraw() {
@@ -337,7 +337,7 @@ export class GraphEditorComponent implements AfterViewInit {
         // TODO:
         // - Serialize selection into dt.
         // dt.setData("application/sinapObjects", )
-        console.log("copy")
+        console.log("copy");
 
         e.preventDefault();
     }
@@ -353,7 +353,7 @@ export class GraphEditorComponent implements AfterViewInit {
         // - Serialize selection into dt.
         // - Delete selection.
         // dt.setData("application/sinapObjects", )
-        console.log("cut")
+        console.log("cut");
 
         e.preventDefault();
     }
@@ -365,7 +365,7 @@ export class GraphEditorComponent implements AfterViewInit {
             // TODO:
             // - Deserialize selection from dt.
             // dt.getData("application/sinapObjects")
-            console.log("paste")
+            console.log("paste");
 
             if (dt.effectAllowed === "move")
                 dt.clearData();
@@ -374,7 +374,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * onMouseDown  
+     * onMouseDown
      *   Handles the mousedown event.
      */
     private onMouseDown
@@ -420,7 +420,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * onMouseMove  
+     * onMouseMove
      *   Handles the mousemove event.
      */
     private onMouseMove
@@ -428,7 +428,7 @@ export class GraphEditorComponent implements AfterViewInit {
         let ePt = this.canvas.getPt(e);
 
         // Capture the down event if the drag object has been set.
-        if (this.dragObject && e.buttons == 1 && !this.downEvt)
+        if (this.dragObject && e.buttons === 1 && !this.downEvt)
             this.downEvt = e;
 
         // Make sure the down event was previously captured.
@@ -476,19 +476,19 @@ export class GraphEditorComponent implements AfterViewInit {
         }
 
         // Panning.
-        else if (e.buttons == 2) {
+        else if (e.buttons === 2) {
             this.pan(e);
             this.panPt = e;
         }
 
         // Hover.
-        else if (e.buttons == 0) {
+        else if (e.buttons === 0) {
             this.updateHoverObject(this.hitPtTest(ePt));
         }
     }
 
     /**
-     * onMouseUp  
+     * onMouseUp
      *   Handles the mouseup event.
      */
     private onMouseUp
@@ -537,14 +537,14 @@ export class GraphEditorComponent implements AfterViewInit {
         }
 
         // Panning.
-        else if (e.buttons == 2) {
+        else if (e.buttons === 2) {
             this.pan(e);
             this.panPt = null;
         }
     }
 
     /**
-     * onWheel  
+     * onWheel
      *   Handles the mouse wheel event for devices that do not register touch
      *   events for zooming.
      */
@@ -558,7 +558,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * onStickey  
+     * onStickey
      *   Delayed mousedown event for creating nodes.
      */
     private onStickey
@@ -582,7 +582,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * onCreatedEdge  
+     * onCreatedEdge
      *   Registers the edge for drawing and listening for property changed
      *   events.
      */
@@ -592,7 +592,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * onCreatedNode  
+     * onCreatedNode
      *   Registers the node for drawing and listening for property changed
      *   events.
      */
@@ -602,7 +602,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * onDeletedEdge  
+     * onDeletedEdge
      *   Unregisters the edge from drawing and removes the event listener for
      *   property changed events.
      */
@@ -613,7 +613,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * onDeletedNode  
+     * onDeletedNode
      *   Unregisters the node from drawing and removes the event listener for
      *   property changed events.
      */
@@ -623,7 +623,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * onDrawablePropertyChanged  
+     * onDrawablePropertyChanged
      *   Updates the drawable and refreshes the canvas if the event source is
      *   a drawable element; otherwise, updates the scale or origin of the
      *   drawable graph.
@@ -661,7 +661,7 @@ export class GraphEditorComponent implements AfterViewInit {
 
 
     /**
-     * registerEventListeners  
+     * registerEventListeners
      *   Registers input event listeners.
      */
     private registerEventListeners() {
@@ -681,7 +681,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * unregisterEventListeners  
+     * unregisterEventListeners
      *   Unregisters event listeners.
      */
     private unregisterEventListeners() {
@@ -699,7 +699,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * registerGraph  
+     * registerGraph
      *   Registers event listeners for the newly bound graph.
      */
     private registerGraph(g: DrawableGraph) {
@@ -727,7 +727,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * unregisterGraph  
+     * unregisterGraph
      *   Unregisters event listeners for the previously bound graph.
      */
     private unregisterGraph(g: DrawableGraph) {
@@ -743,7 +743,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * registerDrawable  
+     * registerDrawable
      *   Registers event listeners for a drawable and adds it to the draw list.
      */
     private registerDrawable(d: DrawableElement) {
@@ -764,7 +764,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * unregisterDrawable  
+     * unregisterDrawable
      *   Unregisters event listeners for a drawable and removes it from the draw
      *   list.
      */
@@ -779,7 +779,7 @@ export class GraphEditorComponent implements AfterViewInit {
 
 
     /**
-     * updateSelectionBox  
+     * updateSelectionBox
      *   Updates the selection box.
      */
     private updateSelectionBox(downPt: pt, ePt: pt): void {
@@ -787,7 +787,7 @@ export class GraphEditorComponent implements AfterViewInit {
 
         // Update the selected components.
         const deselect = [];
-        const select = []
+        const select = [];
         for (const i of [...this.graph.edges, ...this.graph.nodes]) {
             if (i.hitRect(rect))
                 select.push(i);
@@ -805,7 +805,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * updateSelected  
+     * updateSelected
      *   Updates the selected graph element.
      */
     private updateSelected(dragObject: DrawableEdge | DrawableNode) {
@@ -817,7 +817,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * updateDragObject  
+     * updateDragObject
      *   Updates the object being dragged depending on the hovered object.
      */
     private updateDragObject() {
@@ -870,7 +870,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * updateHoverObject  
+     * updateHoverObject
      *   Updates the hovered object and hover anchor.
      */
     private updateHoverObject(value: { d: DrawableElement, pt: point } | null): void {
@@ -928,7 +928,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * updateDragNodes  
+     * updateDragNodes
      *   Updates the collection of nodes being dragged.
      */
     private updateDragNodes(dragNode: DrawableNode, dPt: pt) {
@@ -944,7 +944,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * updateDragNode  
+     * updateDragNode
      *   Updates a single node being dragged.
      */
     private updateDragNode(n: DrawableNode, dPt: pt): void {
@@ -958,7 +958,7 @@ export class GraphEditorComponent implements AfterViewInit {
 
 
     /**
-     * pan  
+     * pan
      *   Repositions the origin point of the canvas.
      */
     private pan(p: pt) {
@@ -973,7 +973,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * zoom  
+     * zoom
      *   Updates the scale of the canvas.
      */
     private zoom(p: pt, s: number) {
@@ -1002,9 +1002,9 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * hitPtTest  
+     * hitPtTest
      *   Gets the first graph component that is hit by a pt.
-     * 
+     *
      * TODO:
      *   Should this return the entity closest to the given point?
      */
@@ -1024,7 +1024,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * resetState  
+     * resetState
      *   Resets input states.
      */
     private resetState() {
@@ -1039,7 +1039,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * loadImage  
+     * loadImage
      *   Loads a node image.
      */
     private loadImage(n: DrawableNode) {
@@ -1055,7 +1055,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * checkValidEdgeDrop  
+     * checkValidEdgeDrop
      *   Checks if dropping an edge will be successfull.
      */
     private checkValidEdgeDrop(e: DrawableEdge, pt: point): boolean {
@@ -1112,7 +1112,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * createDragEdge  
+     * createDragEdge
      *   Creates a ghost edge to be dragged.
      */
     private createDragEdge(
@@ -1133,7 +1133,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * dropEdge  
+     * dropEdge
      *   Drops the dragged edge when the mouse is released.
      */
     private dropEdge(
@@ -1166,7 +1166,7 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
-     * dropNodes  
+     * dropNodes
      *   Drops the collection of nodes or single node that is being dragged
      *   when the mouse is released.
      */
@@ -1190,4 +1190,4 @@ export class GraphEditorComponent implements AfterViewInit {
 
 
 const NOOP: callback
-    = () => { }
+    = () => { };

--- a/app/components/graph-editor/graph-editor.component.ts
+++ b/app/components/graph-editor/graph-editor.component.ts
@@ -15,6 +15,7 @@ import {
 } from "@angular/core";
 
 import {
+    IMAGES,
     GraphEditorCanvas,
     makeRect,
     point
@@ -222,12 +223,18 @@ export class GraphEditorComponent implements AfterViewInit {
     resumeRedraw() {
         if (this.canvas) {
             this.redrawDelegate = () => {
-                this.canvas.clear("#fff");
-                this.canvas.drawGrid();
+                this.canvas.clear();
                 for (const d of this.graph.selectedItems)
                     d.drawSelectionShadow();
+                this.canvas.globalCompositeOperation = "source-in";
+                this.canvas.clear(DEFAULT.SELECTION_COLOR);
+                this.canvas.globalCompositeOperation = "source-over";
                 for (const d of this.drawList)
                     d.draw();
+                this.canvas.globalCompositeOperation = "destination-over";
+                this.canvas.drawGrid();
+                this.canvas.clear("#fff");
+                this.canvas.globalCompositeOperation = "source-over";
             };
             this.redrawDelegate();
         }
@@ -246,7 +253,7 @@ export class GraphEditorComponent implements AfterViewInit {
      */
     // @Input()
     // dragNode(value: DrawableNode) {
-    //     let n = new DrawableNode(value, this.canvas);
+    //     const n = new DrawableNode(value, this.canvas);
     //     this.drawList.push(n);
     //     this.hoverObject = n;
     //     this.updateDragObject();
@@ -290,10 +297,10 @@ export class GraphEditorComponent implements AfterViewInit {
      *   Resizes the canvas.
      */
     resize(): void {
-        let el = this.canvasElementRef.nativeElement;
-        let pel = (el.parentNode as HTMLElement);
-        let h = pel.offsetHeight;
-        let w = pel.offsetWidth;
+        const el = this.canvasElementRef.nativeElement;
+        const pel = (el.parentNode as HTMLElement);
+        const h = pel.offsetHeight;
+        const w = pel.offsetWidth;
         if (this.canvas.size.h != h || this.canvas.size.w != w) {
             this.canvas.size = { h: h, w: w };
             this.redraw();
@@ -429,8 +436,8 @@ export class GraphEditorComponent implements AfterViewInit {
             this.focusHiddenArea();
 
             // Get the change in x and y locations of the cursor.
-            let downPt = this.canvas.getPt(this.downEvt);
-            let dPt = { x: downPt.x - ePt.x, y: downPt.y - ePt.y };
+            const downPt = this.canvas.getPt(this.downEvt);
+            const dPt = { x: downPt.x - ePt.x, y: downPt.y - ePt.y };
 
             // Update the canvas if waiting is not set.
             if (!this.stickyTimeout) {
@@ -501,12 +508,12 @@ export class GraphEditorComponent implements AfterViewInit {
             );
 
             // Get the canvas coordinates of the event.
-            let ePt = this.canvas.getPt(e);
+            const ePt = this.canvas.getPt(e);
 
             // Set the selected graph component if waiting.
             if (this.stickyTimeout) {
                 this.graph.clearSelection();
-                let hit = this.hitPtTest(ePt);
+                const hit = this.hitPtTest(ePt);
                 if (hit)
                     this.graph.selectItems(hit.d);
             }
@@ -558,7 +565,7 @@ export class GraphEditorComponent implements AfterViewInit {
         // Create a new node and reset sticky.
         if (this.downEvt) {
             this.suspendRedraw();
-            let downPt = this.canvas.getPt(this.downEvt);
+            const downPt = this.canvas.getPt(this.downEvt);
             clearTimeout(this.stickyTimeout as NodeJS.Timer);
             this.stickyTimeout = null;
 
@@ -622,9 +629,17 @@ export class GraphEditorComponent implements AfterViewInit {
      */
     private onDrawablePropertyChanged
     = (evt: PropertyChangedEventArgs<any>) => {
-        if (evt.source instanceof DrawableElement) {
+        if (evt.source instanceof DrawableEdge) {
             evt.source.update(this.canvas);
             this.redraw();
+        }
+        else if (evt.source instanceof DrawableNode) {
+            if (evt.key === "shape" && evt.curr === "image")
+                this.loadImage(evt.source);
+            else {
+                evt.source.update(this.canvas);
+                this.redraw();
+            }
         }
         else if (evt.source instanceof DrawableGraph) {
             switch (evt.key) {
@@ -737,7 +752,10 @@ export class GraphEditorComponent implements AfterViewInit {
             });
             this.drawList.push(d.destination, d.source);
         }
-        d.update(this.canvas);
+        if (d instanceof DrawableNode && d.shape === "image")
+            this.loadImage(d);
+        else
+            d.update(this.canvas);
         d.addPropertyChangedListener(this.onDrawablePropertyChanged);
         this.redraw();
     }
@@ -762,11 +780,11 @@ export class GraphEditorComponent implements AfterViewInit {
      *   Updates the selection box.
      */
     private updateSelectionBox(downPt: pt, ePt: pt): void {
-        let rect = makeRect(downPt, ePt);
+        const rect = makeRect(downPt, ePt);
 
         // Update the selected components.
-        let deselect = [];
-        let select = []
+        const deselect = [];
+        const select = []
         for (const i of [...this.graph.edges, ...this.graph.nodes]) {
             if (i.hitRect(rect))
                 select.push(i);
@@ -817,9 +835,9 @@ export class GraphEditorComponent implements AfterViewInit {
 
         // Pick up the edge if one is being hovered.
         else if (this.hoverObject instanceof DrawableEdge) {
-            let spt = this.hoverObject.sourcePoint;
-            let apt = this.hoverObject.source.anchorPoint;
-            let isSrc = spt.x !== apt.x || spt.y !== apt.y;
+            const spt = this.hoverObject.sourcePoint;
+            const apt = this.hoverObject.source.anchorPoint;
+            const isSrc = spt.x !== apt.x || spt.y !== apt.y;
             this.createDragEdge(
                 (isSrc ? this.hoverObject.source : this.hoverObject.destination),
                 isSrc,
@@ -868,8 +886,8 @@ export class GraphEditorComponent implements AfterViewInit {
 
             // Display the anchor point if the hover object is an edge.
             if (value.d instanceof DrawableEdge) {
-                let spt = value.d.sourcePoint;
-                let apt = value.pt;
+                const spt = value.d.sourcePoint;
+                const apt = value.pt;
                 if (spt.x === apt.x && spt.y === apt.y) {
                     value.d.destination.clearAnchor();
                     value.d.source.anchorPoint = apt;
@@ -905,7 +923,7 @@ export class GraphEditorComponent implements AfterViewInit {
     private updateDragNodes(dragNode: DrawableNode, dPt: pt) {
         this.suspendRedraw();
         if (dragNode.isSelected && this.graph.selectedItemCount > 0) {
-            for (let d of this.graph.selectedItems)
+            for (const d of this.graph.selectedItems)
                 if (d instanceof DrawableNode)
                     this.updateDragNode(d, dPt);
         }
@@ -920,7 +938,7 @@ export class GraphEditorComponent implements AfterViewInit {
      */
     private updateDragNode(n: DrawableNode, dPt: pt): void {
         n.position = { x: n.position.x + dPt.x, y: n.position.y + dPt.y };
-        for (let e of n.edges)
+        for (const e of n.edges)
             e.update(this.canvas);
     }
 
@@ -933,10 +951,10 @@ export class GraphEditorComponent implements AfterViewInit {
      *   Repositions the origin point of the canvas.
      */
     private pan(p: pt) {
-        let prev = this.panPt;
-        let curr: pt = p;
+        const prev = this.panPt;
+        const curr: pt = p;
         if (prev) {
-            let dp = { x: curr.x - prev.x, y: curr.y - prev.y };
+            const dp = { x: curr.x - prev.x, y: curr.y - prev.y };
             this.canvas.origin.x += dp.x / this.canvas.scale;
             this.canvas.origin.y += dp.y / this.canvas.scale;
         }
@@ -949,13 +967,13 @@ export class GraphEditorComponent implements AfterViewInit {
      */
     private zoom(p: pt, s: number) {
         // Get the canvas coordinates before zoom.
-        let pt1 = this.canvas.getPt(p);
+        const pt1 = this.canvas.getPt(p);
         // Apply zoom.
         this.scale = this.canvas.scale * s;
         // Get the canvas coordinates after zoom.
-        let pt2 = this.canvas.getPt(p);
+        const pt2 = this.canvas.getPt(p);
         // Get the delta between pre- and post-zoom canvas pts.
-        let dpt = {
+        const dpt = {
             x: pt2.x - pt1.x,
             y: pt2.y - pt1.y
         };
@@ -1010,6 +1028,24 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
+     * loadImage  
+     *   Loads a node image.
+     */
+    private loadImage(n: DrawableNode) {
+        // TODO:
+        // Something about n.image === ""
+        if (!IMAGES.has(n.image)) {
+            const img = new Image();
+            IMAGES.set(n.image, img);
+            img.onload = () => {
+                n.update(this.canvas);
+                this.redraw();
+            };
+            img.src = n.image;
+        }
+    }
+
+    /**
      * checkValidEdgeDrop  
      *   Checks if dropping an edge will be successfull.
      */
@@ -1017,14 +1053,14 @@ export class GraphEditorComponent implements AfterViewInit {
         let hit: { d: DrawableNode, pt: point } | null = null;
         let src = e.source;
         let dst = e.destination;
-        let like = (this.moveEdge ? this.moveEdge : undefined);
-        let nodes = this.drawList.filter(v => {
+        const like = (this.moveEdge ? this.moveEdge : undefined);
+        const nodes = this.drawList.filter(v => {
             return v instanceof DrawableNode;
         }) as DrawableNode[];
 
         // Find the first node on which the edge can be dropped.
-        for (let n of nodes) {
-            let d = n;
+        for (const n of nodes) {
+            const d = n;
             if (n.hitPoint(pt) && this.graph.isValidEdge(
                 (src === this.dragObject ? d : src),
                 (dst === this.dragObject ? d : dst),
@@ -1033,17 +1069,21 @@ export class GraphEditorComponent implements AfterViewInit {
                 // Get the anchor point where the edge will be dropped.
                 src = (src.isHidden ? n : src);
                 dst = (dst.isHidden ? n : dst);
-                let spt = (src === dst ?
+                const spt = (src === dst ?
                     { x: src.position.x, y: src.position.y - 1 } :
                     src.position);
                 src.position;
-                let dpt = dst.position;
-                let u = { x: 0, y: 0 };
-                if (dst === n)
-                    u = { x: spt.x - dpt.x, y: spt.y - dpt.y };
-                else
-                    u = { x: dpt.x - spt.x, y: dpt.y - spt.y };
-                let m = MathEx.mag(u);
+                const dpt = dst.position;
+                const u = { x: 0, y: 0 };
+                if (dst === n) {
+                    u.x = spt.x - dpt.x;
+                    u.y = spt.y - dpt.y;
+                }
+                else {
+                    u.x = dpt.x - spt.x;
+                    u.y = dpt.y - spt.y;
+                }
+                const m = MathEx.mag(u);
                 u.x /= m;
                 u.y /= m;
                 hit = { d: n, pt: n.getBoundaryPt(u) };
@@ -1066,11 +1106,11 @@ export class GraphEditorComponent implements AfterViewInit {
         isSrc: boolean,
         like?: DrawableEdge
     ) {
-        let h = new HiddenNode(this.graph);
+        const h = new HiddenNode(this.graph);
         h.position = this.canvas.getPt(this.downEvt as point);
-        let src = (isSrc ? n : h);
-        let dst = (isSrc ? h : n);
-        let d = new DrawableEdge(this.graph, src, dst, like);
+        const src = (isSrc ? n : h);
+        const dst = (isSrc ? h : n);
+        const d = new DrawableEdge(this.graph, src, dst, like);
         d.isDragging = true;
         this.dragObject = h;
         this.drawList.push(d);
@@ -1084,15 +1124,15 @@ export class GraphEditorComponent implements AfterViewInit {
         graph: DrawableGraph,
         pt: pt
     ): void {
-        let e = this.drawList.pop() as DrawableEdge;
-        let like = (this.moveEdge ? this.moveEdge : undefined);
+        const e = this.drawList.pop() as DrawableEdge;
+        const like = (this.moveEdge ? this.moveEdge : undefined);
         this.moveEdge = null;
         // Move or create the edge if it was dropped on a node.
         if (this.hoverObject instanceof DrawableNode) {
             this.suspendRedraw();
-            let srcNode = (e.source.isHidden ? this.hoverObject : e.source);
-            let dstNode = (e.destination.isHidden ? this.hoverObject : e.destination);
-            let edge = this.graph.createEdge(srcNode, dstNode, like);
+            const srcNode = (e.source.isHidden ? this.hoverObject : e.source);
+            const dstNode = (e.destination.isHidden ? this.hoverObject : e.destination);
+            const edge = this.graph.createEdge(srcNode, dstNode, like);
             if (edge)
                 this.updateSelected(edge);
             this.resumeRedraw();
@@ -1110,7 +1150,7 @@ export class GraphEditorComponent implements AfterViewInit {
      *   when the mouse is released.
      */
     private dropNodes(dragNode: DrawableNode, pt: pt): void {
-        let posn = dragNode.position;
+        const posn = dragNode.position;
         this.updateDragNodes(
             dragNode,
             { x: pt.x - posn.x, y: pt.y - posn.y }

--- a/app/components/graph-editor/math.ts
+++ b/app/components/graph-editor/math.ts
@@ -67,22 +67,22 @@ export function quadBezIntersect(
     lp0: point,
     lp1: point
 ) {
-    let A = lp1.y - lp0.y;
-    let B = lp0.x - lp1.x;
-    let C = -lp0.x * A - lp0.y * B;
+    const A = lp1.y - lp0.y;
+    const B = lp0.x - lp1.x;
+    const C = -lp0.x * A - lp0.y * B;
 
-    let coefs = quadBezCoefs(p0, p1, p2);
-    let a = A * coefs[0].x + B * coefs[0].y;
-    let b = A * coefs[1].x + B * coefs[1].y;
-    let c = A * coefs[2].x + B * coefs[2].y + C;
+    const coefs = quadBezCoefs(p0, p1, p2);
+    const a = A * coefs[0].x + B * coefs[0].y;
+    const b = A * coefs[1].x + B * coefs[1].y;
+    const c = A * coefs[2].x + B * coefs[2].y + C;
 
-    let rts = getQuadraticRoots(a, b, c);
-    for (let t of rts) {
-        let ipt = {
+    const rts = getQuadraticRoots(a, b, c);
+    for (const t of rts) {
+        const ipt = {
             x: coefs[0].x * t * t + coefs[1].x * t + coefs[2].x,
             y: coefs[0].y * t * t + coefs[1].y * t + coefs[2].y
         };
-        let s = (B == 0 ? (ipt.y - lp0.y) / A : (lp0.x - ipt.x) / B);
+        const s = (B == 0 ? (ipt.y - lp0.y) / A : (lp0.x - ipt.x) / B);
         if (s >= 0 && s <= 1)
             return true;
     }
@@ -100,23 +100,23 @@ export function cubBezIntersect(
     // Source:
     // https://www.particleincell.com/2013/cubic-line-intersection/
     // https://www.particleincell.com/wp-content/uploads/2013/08/cubic-line.svg
-    let A = lp1.y - lp0.y;
-    let B = lp0.x - lp1.x;
-    let C = -lp0.x * A - lp0.y * B;
+    const A = lp1.y - lp0.y;
+    const B = lp0.x - lp1.x;
+    const C = -lp0.x * A - lp0.y * B;
 
-    let coefs = cubBezCoefs(p0, p1, p2, p3);
-    let a = A * coefs[0].x + B * coefs[0].y;
-    let b = A * coefs[1].x + B * coefs[1].y;
-    let c = A * coefs[2].x + B * coefs[2].y;
-    let d = A * coefs[3].x + B * coefs[3].y + C;
+    const coefs = cubBezCoefs(p0, p1, p2, p3);
+    const a = A * coefs[0].x + B * coefs[0].y;
+    const b = A * coefs[1].x + B * coefs[1].y;
+    const c = A * coefs[2].x + B * coefs[2].y;
+    const d = A * coefs[3].x + B * coefs[3].y + C;
 
-    let rts = (a == 0 ? getQuadraticRoots(b, c, d) : getCubicRoots(a, b, c, d));
-    for (let t of rts) {
-        let ip = {
+    const rts = (a == 0 ? getQuadraticRoots(b, c, d) : getCubicRoots(a, b, c, d));
+    for (const t of rts) {
+        const ip = {
             x: coefs[0].x * t * t * t + coefs[1].x * t * t + coefs[2].x * t + coefs[3].x,
             y: coefs[0].y * t * t * t + coefs[1].y * t * t + coefs[2].y * t + coefs[3].y
         };
-        let s = (B == 0 ? (ip.y - lp0.y) / A : (lp0.x - ip.x) / B);
+        const s = (B == 0 ? (ip.y - lp0.y) / A : (lp0.x - ip.x) / B);
         if (s >= 0 && s <= 1)
             return true;
     }
@@ -125,7 +125,7 @@ export function cubBezIntersect(
 
 function getQuadraticRoots(a: number, b: number, c: number) {
     a *= 2;
-    let t = [];
+    const t = [];
     let d = b * b - 2 * a * c;
     if (d > 0) {
         d = Math.sqrt(d);
@@ -137,7 +137,7 @@ function getQuadraticRoots(a: number, b: number, c: number) {
             t.push(r);
     }
     else if (d == 0) {
-        let r = -b / (2 * a);
+        const r = -b / (2 * a);
         if (r >= 0 && r <= 1)
             t.push(r);
     }
@@ -148,25 +148,25 @@ function getCubicRoots(a: number, b: number, c: number, d: number) {
     // Source:
     // https://www.particleincell.com/2013/cubic-line-intersection/
     // https://www.particleincell.com/wp-content/uploads/2013/08/cubic-line.svg
-    let t = [];
+    const t = [];
 
-    let A = b / a;
-    let B = c / a;
-    let C = d / a;
+    const A = b / a;
+    const B = c / a;
+    const C = d / a;
 
-    let _A3 = -A / 3;
+    const _A3 = -A / 3;
 
-    let Q = (3 * B - Math.pow(A, 2)) / 9;
-    let Q3 = Math.pow(Q, 3);
-    let R = (9 * A * B - 27 * C - 2 * Math.pow(A, 3)) / 54;
-    let D = Q3 + Math.pow(R, 2);
+    const Q = (3 * B - Math.pow(A, 2)) / 9;
+    const Q3 = Math.pow(Q, 3);
+    const R = (9 * A * B - 27 * C - 2 * Math.pow(A, 3)) / 54;
+    const D = Q3 + Math.pow(R, 2);
 
     if (D >= 0) {
-        let sqrtD = Math.sqrt(D);
+        const sqrtD = Math.sqrt(D);
 
-        let S = sgn(R + sqrtD) * Math.pow(Math.abs(R + sqrtD), 1 / 3);
-        let T = sgn(R - sqrtD) * Math.pow(Math.abs(R - sqrtD), 1 / 3);
-        let ST = S + T;
+        const S = sgn(R + sqrtD) * Math.pow(Math.abs(R + sqrtD), 1 / 3);
+        const T = sgn(R - sqrtD) * Math.pow(Math.abs(R - sqrtD), 1 / 3);
+        const ST = S + T;
 
         let r = _A3 + ST;
         if (r >= 0 && r <= 1)
@@ -179,9 +179,9 @@ function getCubicRoots(a: number, b: number, c: number, d: number) {
         }
     }
     else {
-        let th = Math.acos(R / Math.sqrt(-Q3));
+        const th = Math.acos(R / Math.sqrt(-Q3));
 
-        let sqrtQ = 2 * Math.sqrt(-Q);
+        const sqrtQ = 2 * Math.sqrt(-Q);
         let r = _A3 + sqrtQ * Math.cos(th / 3);
         if (r >= 0 && r <= 1)
             t.push(r);

--- a/app/components/graph-editor/math.ts
+++ b/app/components/graph-editor/math.ts
@@ -15,25 +15,25 @@ import { point } from "./graph-editor-canvas";
 
 
 /**
- * COS_150  
+ * COS_150
  *   Used in the rotation matrix for drawing edge arrows.
  */
 export const COS_150: number = Math.cos(5 * Math.PI / 6);
 
 /**
- * SIN_150  
+ * SIN_150
  *   Used in the rotation matrix for drawing edge arrows.
  */
 export const SIN_150: number = Math.sin(5 * Math.PI / 6);
 
 /**
- * COS_22_5  
+ * COS_22_5
  *   Used in the rotation matrix for calculating edge loopback points.
  */
 export const COS_22_5: number = Math.cos(Math.PI / 8);
 
 /**
- * SIN_22_5  
+ * SIN_22_5
  *   Used in the rotation matrix for calculating edge loopback points.
  */
 export const SIN_22_5: number = Math.sin(Math.PI / 8);
@@ -45,7 +45,7 @@ export const SQRT3 = Math.sqrt(3);
 
 
 /**
- * dot  
+ * dot
  *   Calculates the dot product of two points.
  */
 export function dot(a: point, b: point): number {
@@ -53,7 +53,7 @@ export function dot(a: point, b: point): number {
 }
 
 /**
- * mag  
+ * mag
  *   Calculates the magnitude of a point.
  */
 export function mag(v: point): number {
@@ -82,7 +82,7 @@ export function quadBezIntersect(
             x: coefs[0].x * t * t + coefs[1].x * t + coefs[2].x,
             y: coefs[0].y * t * t + coefs[1].y * t + coefs[2].y
         };
-        const s = (B == 0 ? (ipt.y - lp0.y) / A : (lp0.x - ipt.x) / B);
+        const s = (B === 0 ? (ipt.y - lp0.y) / A : (lp0.x - ipt.x) / B);
         if (s >= 0 && s <= 1)
             return true;
     }
@@ -110,13 +110,13 @@ export function cubBezIntersect(
     const c = A * coefs[2].x + B * coefs[2].y;
     const d = A * coefs[3].x + B * coefs[3].y + C;
 
-    const rts = (a == 0 ? getQuadraticRoots(b, c, d) : getCubicRoots(a, b, c, d));
+    const rts = (a === 0 ? getQuadraticRoots(b, c, d) : getCubicRoots(a, b, c, d));
     for (const t of rts) {
         const ip = {
             x: coefs[0].x * t * t * t + coefs[1].x * t * t + coefs[2].x * t + coefs[3].x,
             y: coefs[0].y * t * t * t + coefs[1].y * t * t + coefs[2].y * t + coefs[3].y
         };
-        const s = (B == 0 ? (ip.y - lp0.y) / A : (lp0.x - ip.x) / B);
+        const s = (B === 0 ? (ip.y - lp0.y) / A : (lp0.x - ip.x) / B);
         if (s >= 0 && s <= 1)
             return true;
     }
@@ -136,7 +136,7 @@ function getQuadraticRoots(a: number, b: number, c: number) {
         if (r >= 0 && r <= 1)
             t.push(r);
     }
-    else if (d == 0) {
+    else if (d === 0) {
         const r = -b / (2 * a);
         if (r >= 0 && r <= 1)
             t.push(r);
@@ -172,7 +172,7 @@ function getCubicRoots(a: number, b: number, c: number, d: number) {
         if (r >= 0 && r <= 1)
             t.push(r);
 
-        if (S - T == 0) {
+        if (S - T === 0) {
             r = _A3 - ST / 2;
             if (r >= 0 && r <= 1)
                 t.push(r);
@@ -211,7 +211,7 @@ function quadBezCoefs(p0: point, p1: point, p2: point) {
 }
 
 /**
- * cubBezCoefs  
+ * cubBezCoefs
  *   Gets the cubic bezier curve coefficients.
  */
 function cubBezCoefs(p0: point, p1: point, p2: point, p3: point) {

--- a/plugins/accept_state.svg
+++ b/plugins/accept_state.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="42" width="42">
+<circle cx="21" cy="21" r="20" stroke="black" stroke-width="2" fill="#fff200" />
+<circle cx="21" cy="21" r="17" stroke="black" stroke-width="1" fill="transparent" />
+</svg>

--- a/plugins/and_gate.svg
+++ b/plugins/and_gate.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="50" width="50">
+<path d="
+M 0 15 H 10
+M 0 35 H 10
+M 10 10 H 25
+M 10 40 H 25
+M 40 25 H 50
+M 10 10 V 40
+M 25 10 A 15 15 0 0 1 25 40"
+stroke="black"
+stroke-width="2"
+fill="transparent"
+/>
+</svg>

--- a/plugins/start_state.svg
+++ b/plugins/start_state.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="42" width="62">
+<path d="M 1 1 V 40 L 21 21 Z"
+stroke="black"
+stroke-width="2"
+fill="white"
+/>
+<circle cx="41" cy="21" r="20" stroke="black" stroke-width="2" fill="#fff200" />
+</svg>


### PR DESCRIPTION
* Added support for custom images
  - `Shapes` now has an additional type in its union: "image"
* Added support for custom anchor points
* Drawable nodes now have two new public fields: `image` and `anchorPoints`
  - The `image` field is a string representing the path (preferably absolute) to the image file
  - The `anchorPoints` field is a list of points
    + Points with duplicate coordinates are removed
    + The coordinates of an anchor point is relative to the upper left corner of a node