### PR TITLE
Stacked edge labels

### DIFF
--- a/app/components/graph-editor/drawable-element.ts
+++ b/app/components/graph-editor/drawable-element.ts
@@ -4,6 +4,7 @@
 
 
 import { FONT_SIZE } from "./defaults";
+import { NOOP } from "./math";
 import { GraphEditorCanvas, point, rect, size } from "./graph-editor-canvas";
 import { Drawable } from "./drawable";
 import { DrawableGraph } from "./drawable-graph";
@@ -105,12 +106,12 @@ export abstract class DrawableElement extends Drawable {
             _draw: {
                 enumerable: false,
                 writable: true,
-                value: () => { }
+                value: NOOP
             },
             _drawSelectionShadow: {
                 enumerable: false,
                 writable: true,
-                value: () => { }
+                value: NOOP
             },
             graph: {
                 enumerable: false,

--- a/app/components/graph-editor/drawable-node.ts
+++ b/app/components/graph-editor/drawable-node.ts
@@ -482,7 +482,7 @@ export class DrawableNode extends DrawableElement {
                     case "image":
                         for (let i = 0; i < offsets.length; i += 2) {
                             const opt = { x: pt.x + offsets[i], y: pt.y + offsets[i + 1] };
-                            g.drawImage(opt, IMAGES.get(this._img)!);
+                            g.drawImage(opt, IMAGES.get(this._img) !);
                         }
                         break;
                 }
@@ -505,7 +505,7 @@ export class DrawableNode extends DrawableElement {
                     g.drawSquare(pt, sz.w, bs, bw, bc, cl, sc);
                     break;
                 case "image":
-                    g.drawImage(pt, IMAGES.get(this._img)!, sc);
+                    g.drawImage(pt, IMAGES.get(this._img) !, sc);
                     break;
             }
         };

--- a/app/components/graph-editor/drawable-node.ts
+++ b/app/components/graph-editor/drawable-node.ts
@@ -409,7 +409,7 @@ export class DrawableNode extends DrawableElement {
         const old = this.edges;
         if (e.source === this)
             this._outgoingSet.add(e);
-        else if (e.destination === this)
+        if (e.destination === this)
             this._incomingSet.add(e);
         this.onPropertyChanged("edges", old);
     }
@@ -482,7 +482,7 @@ export class DrawableNode extends DrawableElement {
                     case "image":
                         for (let i = 0; i < offsets.length; i += 2) {
                             const opt = { x: pt.x + offsets[i], y: pt.y + offsets[i + 1] };
-                            g.drawImage(opt, IMAGES.get(this._img) !);
+                            g.drawImage(opt, IMAGES.get(this._img)!);
                         }
                         break;
                 }
@@ -491,7 +491,7 @@ export class DrawableNode extends DrawableElement {
                 sc = undefined;
         }
         else {
-            this._drawSelectionShadow = () => { };
+            this._drawSelectionShadow = MathEx.NOOP;
         }
         //////////////
         // Set node //
@@ -505,7 +505,7 @@ export class DrawableNode extends DrawableElement {
                     g.drawSquare(pt, sz.w, bs, bw, bc, cl, sc);
                     break;
                 case "image":
-                    g.drawImage(pt, IMAGES.get(this._img) !, sc);
+                    g.drawImage(pt, IMAGES.get(this._img)!, sc);
                     break;
             }
         };
@@ -698,7 +698,7 @@ export class HiddenNode extends DrawableNode {
     update(g: GraphEditorCanvas) { }
 
     updateDraw(g: GraphEditorCanvas) {
-        this._draw = () => { };
+        this._draw = MathEx.NOOP;
     }
 
     getBoundaryPt(u: point) {

--- a/app/components/graph-editor/graph-editor.component.ts
+++ b/app/components/graph-editor/graph-editor.component.ts
@@ -165,13 +165,13 @@ export class GraphEditorComponent implements AfterViewInit {
      *   For suspending and resuming draw calls.
      */
     private redrawDelegate: callback
-    = NOOP;
+    = MathEx.NOOP;
 
     private deleteSelectedDelegate: callback
-    = NOOP;
+    = MathEx.NOOP;
 
     private selectAllDelegate: callback
-    = NOOP;
+    = MathEx.NOOP;
 
 
     // Public Fields ///////////////////////////////////////////////////////////
@@ -215,7 +215,7 @@ export class GraphEditorComponent implements AfterViewInit {
      *   Suspends updates to the canvas.
      */
     suspendRedraw() {
-        this.redrawDelegate = NOOP;
+        this.redrawDelegate = MathEx.NOOP;
     }
 
     /**
@@ -762,8 +762,8 @@ export class GraphEditorComponent implements AfterViewInit {
      *   Unregisters event listeners for the previously bound graph.
      */
     private unregisterGraph(g: DrawableGraph) {
-        this.deleteSelectedDelegate = NOOP;
-        this.selectAllDelegate = NOOP;
+        this.deleteSelectedDelegate = MathEx.NOOP;
+        this.selectAllDelegate = MathEx.NOOP;
         g.removeCreatedEdgeListener(this.onCreatedEdges);
         g.removeCreatedNodeListener(this.onCreatedNodes);
         g.removeDeletedEdgeListener(this.onDeletedEdges);
@@ -1210,10 +1210,3 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
 }
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-
-const NOOP: callback
-    = () => { };

--- a/app/components/graph-editor/math.ts
+++ b/app/components/graph-editor/math.ts
@@ -40,6 +40,7 @@ export const SIN_22_5: number = Math.sin(Math.PI / 8);
 
 export const SQRT3 = Math.sqrt(3);
 
+export const NOOP = () => { };
 
 // Functions ///////////////////////////////////////////////////////////////////
 
@@ -58,6 +59,28 @@ export function dot(a: point, b: point): number {
  */
 export function mag(v: point): number {
     return Math.sqrt(dot(v, v));
+}
+
+/**
+ * normal
+ *
+ *   Gets the unit normal vector of the given vector.
+ *
+ *
+ * @param v
+ *   The vector with which to get the normal.
+ */
+export function normal(v: point): point {
+    const d = mag(v);
+    return { x: v.y / d, y: v.x / d };
+}
+
+export function add(a: point, b: point): point {
+    return { x: a.x + b.x, y: a.y + b.y };
+}
+
+export function subtract(a: point, b: point): point {
+    return { x: a.x - b.x, y: a.y - b.y };
 }
 
 export function quadBezIntersect(
@@ -235,6 +258,6 @@ function cubBezCoefs(p0: point, p1: point, p2: point, p3: point) {
     ];
 }
 
-function sgn(n: number) {
+export function sgn(n: number) {
     return (n < 0 ? -1 : 1);
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./dist && rimraf ./dll",
     "webpack": "webpack --progress --profile --colors --display-error-details --display-cached",
-    "format": "tslint --project . --fix",
+    "format": "tsfmt -r && tslint --project . --fix",
     "lint": "tsfmt --verify && tslint --project .",
     "build": "npm run format && npm run webpack",
     "build:dll": "npm run webpack -- --config webpack.dll.config.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./dist && rimraf ./dll",
     "webpack": "webpack --progress --profile --colors --display-error-details --display-cached",
-    "format": "tsfmt -r && tslint --project . --fix",
+    "format": "tslint --project . --fix",
     "lint": "tsfmt --verify && tslint --project .",
     "build": "npm run format && npm run webpack",
     "build:dll": "npm run webpack -- --config webpack.dll.config.js",


### PR DESCRIPTION
Hit detection also works on the floating labels for edges. Depending on which horizontal half of the label the cursor is on, either the source or destination endpoint of the edge will be picked up when dragging.

The labels will always be on the same side of the edge, regardless of the edge's global orientation. To see this in action, create two nodes and four edges with labels between them--each pair of edges opposing the other--and orbit one of the nodes around the other by dragging.

