### PR TITLE
Editor input changes

### DIFF
--- a/app/components/graph-editor/drawable-graph.ts
+++ b/app/components/graph-editor/drawable-graph.ts
@@ -570,19 +570,17 @@ export class DrawableGraph extends Drawable {
     ) {
         const oldSelection = [...this._selected];
         move(src, dst, items, v => v.isSelected = (dst === this._selected));
-        if (oldSelection.length !== this._selected.size) {
-            this.dispatchEvent(
-                new TypedCustomEvent(
-                    "select",
-                    new PropertyChangedEventDetail<Iterable<DrawableElement>>(
-                        this,
-                        "selectedItems",
-                        oldSelection,
-                        [...this._selected]
-                    )
+        this.dispatchEvent(
+            new TypedCustomEvent(
+                "select",
+                new PropertyChangedEventDetail<Iterable<DrawableElement>>(
+                    this,
+                    "selectedItems",
+                    oldSelection,
+                    [...this._selected]
                 )
-            );
-        }
+            )
+        );
     }
 
 }

--- a/app/components/graph-editor/editor-canvas.ts
+++ b/app/components/graph-editor/editor-canvas.ts
@@ -477,7 +477,7 @@ export class EditorCanvas {
                 break;
 
             default:
-                this.g.setLineDash([1, 0]);
+                this.g.setLineDash([]);
         }
     }
 

--- a/app/components/graph-editor/editor-node.ts
+++ b/app/components/graph-editor/editor-node.ts
@@ -71,7 +71,7 @@ export class EditorNode extends EditorElement<DrawableNode> {
 
     private trace = (g: EditorCanvas) => { };
 
-    private stroke = (g: EditorCanvas, extraLineWidth: number = 0) => { };
+    private stroke = (g: EditorCanvas) => { };
 
     private fill = (g: EditorCanvas) => { };
 
@@ -190,6 +190,7 @@ export class EditorNode extends EditorElement<DrawableNode> {
         g.fillColor = "#fff";
         g.strokeColor = "#000";
         g.lineWidth = 2;
+        g.lineStyle = "solid";
         this.lines.forEach(l => {
             g.strokeText(l, x, y);
             g.fillText(l, x, y);
@@ -322,10 +323,10 @@ export class EditorNode extends EditorElement<DrawableNode> {
     private updateStroke() {
         const drawable = this.drawable;
         if (drawable.shape === "image" || drawable.borderWidth === 0)
-            this.stroke = (g: EditorCanvas, extraLineWidth: number = 0) => { };
+            this.stroke = (g: EditorCanvas) => { };
         else
-            this.stroke = (g: EditorCanvas, extraLineWidth: number = 0) => {
-                g.lineWidth = this.drawable.borderWidth + extraLineWidth;
+            this.stroke = (g: EditorCanvas) => {
+                g.lineWidth = this.drawable.borderWidth;
                 g.lineStyle = this.drawable.borderStyle;
                 g.strokeColor = this.drawable.borderColor;
                 g.stroke();
@@ -426,7 +427,10 @@ export class EditorNode extends EditorElement<DrawableNode> {
         else {
             this._drawHighlight = (g: EditorCanvas) => {
                 this.trace(g);
-                this.stroke(g, 6);
+                g.lineStyle = "solid";
+                g.lineWidth = this.drawable.borderWidth + 6;
+                g.strokeColor = this.drawable.borderColor;
+                g.stroke();
             };
         }
     }
@@ -443,6 +447,7 @@ export class EditorNode extends EditorElement<DrawableNode> {
                 g.fillColor = "#fff";
                 g.strokeColor = "#000";
                 g.lineWidth = 1;
+                g.lineStyle = "solid";
                 g.fill();
                 g.stroke();
             };

--- a/app/components/graph-editor/graph-editor.component.ts
+++ b/app/components/graph-editor/graph-editor.component.ts
@@ -291,7 +291,7 @@ export class GraphEditorComponent implements AfterViewInit {
         this.graphCanvas = new EditorCanvas(
             this.graphLayerElementRef.nativeElement.getContext("2d")
         );
-        this.graphLayerElementRef.nativeElement.onselectstart = function() { return false; };
+        this.graphLayerElementRef.nativeElement.onselectstart = () => false;
         this.resize();
     }
 
@@ -370,6 +370,7 @@ export class GraphEditorComponent implements AfterViewInit {
     private registerEventListeners() {
         const el = this.el.nativeElement as HTMLElement;
         el.addEventListener("keydown", this.onKeyDown);
+        el.addEventListener("keyup", this.onKeyUp);
         el.addEventListener("dblclick", this.onDoubleClick);
         el.addEventListener("mousedown", this.onMouseDown);
         el.addEventListener("mousemove", this.onMouseMove);
@@ -392,6 +393,7 @@ export class GraphEditorComponent implements AfterViewInit {
     private unregisterEventListeners() {
         const el = this.el.nativeElement as EventTarget;
         el.removeEventListener("keydown", this.onKeyDown);
+        el.removeEventListener("keyup", this.onKeyUp);
         el.removeEventListener("dblclick", this.onDoubleClick);
         el.removeEventListener("mousedown", this.onMouseDown);
         el.removeEventListener("mouseup", this.onMouseUp);
@@ -540,6 +542,16 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
+     * `onKeyUp`
+     *
+     *   Handles the keyup event.
+     */
+    private onKeyUp
+    = (evt: KeyboardEvent) => {
+        this.el.nativeElement.style.cursor = "default";
+    }
+
+    /**
      * `onDoubleClick`
      *
      *   Handles the double click event.
@@ -547,8 +559,10 @@ export class GraphEditorComponent implements AfterViewInit {
     private onDoubleClick
     = (evt: MouseEvent) => {
         const d = this._graph!.drawable.createNode();
-        if (d)
+        if (d) {
             d.position = this.graphCanvas.getCoordinates(evt);
+            this._graph!.drawable.setSelected(d);
+        }
     }
 
     /**

--- a/app/components/graph-editor/graph-editor.component.ts
+++ b/app/components/graph-editor/graph-editor.component.ts
@@ -291,6 +291,7 @@ export class GraphEditorComponent implements AfterViewInit {
         this.graphCanvas = new EditorCanvas(
             this.graphLayerElementRef.nativeElement.getContext("2d")
         );
+        this.graphLayerElementRef.nativeElement.onselectstart = function() { return false; };
         this.resize();
     }
 

--- a/app/components/graph-editor/graph-editor.component.ts
+++ b/app/components/graph-editor/graph-editor.component.ts
@@ -134,7 +134,7 @@ export class GraphEditorComponent implements AfterViewInit {
 
     /**
      * `downPt`
-     * 
+     *
      *   The previously captured mouse down event.
      */
     private downPt: point | null

--- a/app/components/graph-editor/graph-editor.component.ts
+++ b/app/components/graph-editor/graph-editor.component.ts
@@ -368,6 +368,7 @@ export class GraphEditorComponent implements AfterViewInit {
      */
     private registerEventListeners() {
         const el = this.el.nativeElement as HTMLElement;
+        el.addEventListener("keydown", this.onKeyDown);
         el.addEventListener("dblclick", this.onDoubleClick);
         el.addEventListener("mousedown", this.onMouseDown);
         el.addEventListener("mousemove", this.onMouseMove);
@@ -389,6 +390,7 @@ export class GraphEditorComponent implements AfterViewInit {
      */
     private unregisterEventListeners() {
         const el = this.el.nativeElement as EventTarget;
+        el.removeEventListener("keydown", this.onKeyDown);
         el.removeEventListener("dblclick", this.onDoubleClick);
         el.removeEventListener("mousedown", this.onMouseDown);
         el.removeEventListener("mouseup", this.onMouseUp);
@@ -526,6 +528,17 @@ export class GraphEditorComponent implements AfterViewInit {
     }
 
     /**
+     * `onKeyDown`
+     *
+     *   Handles the keydown event.
+     */
+    private onKeyDown
+    = (evt: KeyboardEvent) => {
+        if (evt.altKey)
+            this.el.nativeElement.style.cursor = "-webkit-grab";
+    }
+
+    /**
      * `onDoubleClick`
      *
      *   Handles the double click event.
@@ -560,7 +573,7 @@ export class GraphEditorComponent implements AfterViewInit {
                 this._graph!.dragStart(this.graphCanvas.getCoordinates(evt));
             }
             else if (evt.altKey) {
-                this.el.nativeElement.style.cursor = "grabbing";
+                this.el.nativeElement.style.cursor = "-webkit-grabbing";
                 this.isPanning = true;
             }
             else {
@@ -573,7 +586,8 @@ export class GraphEditorComponent implements AfterViewInit {
                             clearTimeout(this.stickyTimeout as NodeJS.Timer);
                             this.stickyTimeout = null;
                             this.downPt = null;
-                            this.el.nativeElement.style.cursor = "grabbing";
+                            this.el.nativeElement.style.cursor
+                                = "-webkit-grabbing";
                             this.isPanning = true;
                         }, STICKY_DELAY);
                 }
@@ -606,7 +620,7 @@ export class GraphEditorComponent implements AfterViewInit {
             // Drag.
             case 1: {
                 if (this.isPanning) {
-                    this.el.nativeElement.style.cursor = "grabbing";
+                    this.el.nativeElement.style.cursor = "-webkit-grabbing";
                     this.pan(evt);
                 }
                 else if (this.stickyTimeout) {


### PR DESCRIPTION
Addresses #264 and #223 

There's a bug with double clicking that I couldn't figure out. Every time the user double clicks on the canvas, the text in the status bar is selected regardless of whether or not `stopPropagation`, `stopImmediatePropagation`, or `preventDefault` is called on the event payload.