### PR TITLE
Added ability to open a plugin in the file manager.

### DIFF
--- a/app/components/plugin-manager/plugin-manager.component.html
+++ b/app/components/plugin-manager/plugin-manager.component.html
@@ -22,7 +22,7 @@
         <div class="buttons-row">
             <button (click)="deletePlugin()">Delete</button>
             <button (click)="editButton()">Edit</button>
-            <button (click)="showInFolder()">Open in Explorer</button>
+            <button (click)="showInFolder()">{{getFileManagerText()}}</button>
         </div>
     </div>
 </div>

--- a/app/components/plugin-manager/plugin-manager.component.html
+++ b/app/components/plugin-manager/plugin-manager.component.html
@@ -20,7 +20,9 @@
             <p>{{selectedPlugin.description}}</p>
         </div>
         <div class="buttons-row">
-            <button (click)="deletePlugin()">Delete</button><button (click)="editButton()">Edit</button>
+            <button (click)="deletePlugin()">Delete</button>
+            <button (click)="editButton()">Edit</button>
+            <button (click)="showInFolder()">Open in Explorer</button>
         </div>
     </div>
 </div>

--- a/app/components/plugin-manager/plugin-manager.component.scss
+++ b/app/components/plugin-manager/plugin-manager.component.scss
@@ -82,6 +82,6 @@ input, button {
 
     button {
         display: inline-block;
-        width: 7em;
+        width: 10em;
     }
 }

--- a/app/components/plugin-manager/plugin-manager.component.ts
+++ b/app/components/plugin-manager/plugin-manager.component.ts
@@ -93,6 +93,14 @@ export class PluginManager implements ModalComponent {
         }
     }
 
+    private getFileManagerText() {
+        if (process.platform === 'darwin') {
+            return "Reveal in Finder";
+        } else {
+            return "Open in Explorer";
+        }
+    }
+
     async importPlugins() {
         const dirNames = await requestOpenDirs(DEFAULT_DIR);
         await this.importMany(dirNames);

--- a/app/components/plugin-manager/plugin-manager.component.ts
+++ b/app/components/plugin-manager/plugin-manager.component.ts
@@ -1,12 +1,13 @@
 import { Component, Inject, Output, ChangeDetectorRef } from "@angular/core";
-import { PluginService } from "../../services/plugin.service";
+import { PluginService, PLUGIN_DIRECTORY } from "../../services/plugin.service";
 import { requestSaveFile, requestOpenDirs, requestFiles, getLogger } from "../../util";
-import { remote } from "electron";
+import { remote, shell } from "electron";
 import { ZIP_FILE_FILTER } from "../../constants";
 import { ModalComponent, ModalInfo } from "../../models/modal-window";
 import { getPluginInfo, PluginInfo } from "sinap-core";
-import { dirFiles, subdirs, tempDir, unzip, TempDir } from "../../util";
+import { dirFiles, subdirs, tempDir, unzip, TempDir, getPath } from "../../util";
 import { WindowService } from "./../../modal-windows/services/window.service";
+import * as path from "path";
 
 let exec = require('child_process').exec;
 
@@ -82,6 +83,14 @@ export class PluginManager implements ModalComponent {
         await Promise.all(proms);
         this.plugins = await this.pluginService.pluginData;
         this.changeDetectorRef.detectChanges();
+    }
+
+    private showInFolder() {
+        const directory = getPath(path.join(this.selectedPlugin.interpreterInfo.directory, "package.json"));
+        LOG.info(`Opening ${directory} in file manager.`);
+        if (!shell.showItemInFolder(directory)) {
+            LOG.error(`Could not open ${directory} in file manager.`);
+        }
     }
 
     async importPlugins() {

--- a/app/index.ts
+++ b/app/index.ts
@@ -92,7 +92,7 @@ function bufferModalWindow() {
     nextModal = new BrowserWindow({
         parent: win,
         modal: true,
-        width: 600,
+        width: 650,
         height: 450,
         center: true,
         resizable: true,

--- a/app/util.ts
+++ b/app/util.ts
@@ -57,7 +57,7 @@ export function somePromises<T>(promises: Iterable<Promise<T>>, logger: Logger):
 }
 
 export function getPath(name: string) {
-    return path.normalize("/" + path.relative("/", name));
+    return path.resolve(path.normalize(name));
 }
 
 export function compareFiles(file1: string, file2: string) {


### PR DESCRIPTION
I think this is nice for more general/complicated plugins. I'm going to work on the duplicate folder issue, but this was a quick fix.

This should be cross platform since I'm just using a built in electron API.

@Sheyne I'm really interested as to what you think.

Also fixed a bug with getPath for Windows.