### PR TITLE
Undo/Redo v2

### DIFF
--- a/app/components/graph-editor/drawable-graph.ts
+++ b/app/components/graph-editor/drawable-graph.ts
@@ -125,7 +125,10 @@ export class DrawableGraph extends Drawable {
                 enumerable: true,
                 get: () => this._origin,
                 set: (value: point) => {
-                    const old = this.origin;
+                    const old = {
+                        x: this._origin.x,
+                        y: this._origin.y
+                    };
                     if (value.x !== old.x || value.y !== old.y) {
                         this._origin.x = value.x;
                         this._origin.y = value.y;

--- a/app/components/graph-editor/graph-editor.component.ts
+++ b/app/components/graph-editor/graph-editor.component.ts
@@ -268,6 +268,9 @@ export class GraphEditorComponent implements AfterViewInit {
         if (this.graphCanvas) {
             this.graphCanvas.origin = value;
         }
+
+        this._graph!.drawable.origin = value;
+
         this.redraw();
     }
 
@@ -494,6 +497,7 @@ export class GraphEditorComponent implements AfterViewInit {
             x: canvas.origin.x + evt.x / canvas.scale,
             y: canvas.origin.y + evt.y / canvas.scale
         };
+
         this.redraw();
     }
 

--- a/app/components/main/main.component.ts
+++ b/app/components/main/main.component.ts
@@ -147,8 +147,6 @@ export class MainComponent implements OnInit, AfterViewInit, AfterViewChecked, M
     private set context(context: TabContext | undefined) {
         this._context = context;
         if (context) {
-            context.compileProgram();
-
             this.toolsPanelData.graph = context.graph;
             this.filesPanelData.selectedFile = context.file;
             this.statusBar.info = context.statusBarInfo;
@@ -199,7 +197,6 @@ export class MainComponent implements OnInit, AfterViewInit, AfterViewChecked, M
             let tabNumber = this.tabBar.newTab(context);
             this.tabs.set(tabNumber, context);
 
-            graph.changed.asObservable().subscribe(this.makeChangeNotifier(context));
             this.selectedTab(tabNumber);
         });
     }
@@ -225,13 +222,6 @@ export class MainComponent implements OnInit, AfterViewInit, AfterViewChecked, M
         // if (isDirty) {
         //     return confirm('You have unsaved files, are you sure you wish to quit?');
         // }
-    }
-
-
-    private makeChangeNotifier(context: TabContext) {
-        return (change: UndoableEvent) => {
-            context.compileProgram();
-        };
     }
 
     async launchPluginManager() {

--- a/app/components/main/tab-context.ts
+++ b/app/components/main/tab-context.ts
@@ -140,7 +140,7 @@ export class TabContext {
 
             this.undoHistory.push(this.pendingChanges);
             this.pendingChanges = [];
-        }, 200) as any;
+        }, 100) as any;
     }
 
     private recompileIfNeccesary(changes: UndoableEvent[]) {

--- a/app/components/types/type-injector/type-injector.component.ts
+++ b/app/components/types/type-injector/type-injector.component.ts
@@ -75,13 +75,17 @@ export class TypeInjectorComponent {
             this.container.clear();
             this.component = undefined;
         }
-        // TODO: Sheyne, deepEqual after a couple recursive calls throws an exception.
-        // else if (this.component && this._value && this._value.deepEqual(v)) {
-        //     if (this._value !== v) {
-        //         this._value = v;
-        //         this.component.instance.value = v;
-        //     }
-        // }
+        else if (this.component && this._value) {
+            try {
+                if (this._value.deepEqual(v) && this._value !== v) {
+                    this._value = v;
+                    this.component.instance.value = v;
+                }
+            } catch (e) {
+                console.log(e);
+                // TODO: Sheyne, deepEqual after a couple recursive calls throws an exception when running dfs.
+            }
+        }
         else {
             this.inject(v, this.readonly, this._disabled, this.graph);
         }

--- a/app/components/types/type-injector/type-injector.component.ts
+++ b/app/components/types/type-injector/type-injector.component.ts
@@ -80,9 +80,12 @@ export class TypeInjectorComponent {
                 if (this._value.deepEqual(v) && this._value !== v) {
                     this._value = v;
                     this.component.instance.value = v;
+                } else {
+                    this.inject(v, this.readonly, this._disabled, this.graph);
                 }
             } catch (e) {
                 console.log(e);
+                this.inject(v, this.readonly, this._disabled, this.graph);
                 // TODO: Sheyne, deepEqual after a couple recursive calls throws an exception when running dfs.
             }
         }

--- a/app/models/bridge.ts
+++ b/app/models/bridge.ts
@@ -83,10 +83,11 @@ export class Bridge {
 
         this.drawableListener = (evt: PropertyChangedEvent<any>) => {
             const f = () => this.sync(() => {
+                const previous = JSON.parse(JSON.stringify(evt.detail.prev));
+                const current = JSON.parse(JSON.stringify(evt.detail.curr));
+
                 const result = this.graph.copyPropertyToCore(this.drawable, this.core, evt.detail.key.toString());
                 if (result) {
-                    const previous = evt.detail.prev;
-                    const current = JSON.parse(JSON.stringify(evt.detail.curr)); // TODO: this feels pretty bad...
                     const undo: UndoableEvent = new UndoableEvent(false, () => {
                         this.sync(() => {
                             (this.drawable as any)[evt.detail.key] = previous;

--- a/app/models/bridge.ts
+++ b/app/models/bridge.ts
@@ -53,8 +53,6 @@ export class Bridge {
                 }).forEach(([k, _]) => {
                     this.graph.copyPropertyToDrawable(core.get(k), drawable, k);
 
-                    console.log(value, other);
-
                     // TODO: Can only undo primitive and union changes.
                     if (value instanceof Value.Primitive || value instanceof Value.Union) {
                         const undo: UndoableEvent = new UndoableEvent(true, () => {

--- a/app/models/bridge.ts
+++ b/app/models/bridge.ts
@@ -21,9 +21,11 @@ export class Bridge {
         const updateComputedProperties = () => {
             if (timer) clearTimeout(timer);
             timer = setTimeout(() => {
-                computedPropertyContext.update();
-                [...computedPropertyContext.properties.entries()].forEach(([key, [name, value]]) => {
-                    this.graph.copyPropertyToDrawable(value, drawable, key);
+                this.sync(() => {
+                    computedPropertyContext.update();
+                    [...computedPropertyContext.properties.entries()].forEach(([key, [name, value]]) => {
+                        this.graph.copyPropertyToDrawable(value, drawable, key);
+                    });
                 });
             }, timer ? 100 : 0) as any;
         };
@@ -129,10 +131,9 @@ export class ComputedPropertyContext {
     public readonly properties = new Map<string, [string, Value.Value]>();
     public onUpdate?: (() => void) = undefined;
 
-    constructor(public readonly value: ElementValue) {};
+    constructor(public readonly value: ElementValue) { };
 
     update() {
-        console.log("Updating computed properties");
         [...this.value.type.pluginType.methods.entries()].filter(([_, method]) => method.isGetter).forEach(([key, _]) => {
             let v = this.value.call(key);
             if (v) {

--- a/app/models/bridge.ts
+++ b/app/models/bridge.ts
@@ -1,22 +1,10 @@
-import { EventEmitter } from "@angular/core";
 import {
-    DrawableElement,
     Drawable,
-    DrawableGraph,
-    DrawableEdge,
-    DrawableNode,
-    EdgeValidator,
-    DrawableEvent,
-    MoveEdgeEvent,
     PropertyChangedEvent,
-    PropertyChangedEventDetail,
-    SelectionChangedEvent
 } from "../components/graph-editor/graph-editor.component";
-import { Model, Plugin, ElementValue, ElementType } from "sinap-core";
-import { Value, Type } from "sinap-types";
-import { DoubleMap } from "./double-map";
+import { ElementValue, } from "sinap-core";
+import { Value } from "sinap-types";
 import { GraphController, UndoableEvent } from "./graph-controller";
-import { getPath } from "../util";
 
 export class Bridge {
     private isSyncing = false;
@@ -118,7 +106,6 @@ export class Bridge {
     };
 
     public undeleted() {
-        console.log("undeleted");
         this.core.environment.listen(this.coreListener, () => true, this.core);
         this.drawable.addEventListener("change", this.drawableListener);
     }

--- a/app/models/bridge.ts
+++ b/app/models/bridge.ts
@@ -1,0 +1,158 @@
+import { EventEmitter } from "@angular/core";
+import {
+    DrawableElement,
+    Drawable,
+    DrawableGraph,
+    DrawableEdge,
+    DrawableNode,
+    EdgeValidator,
+    DrawableEvent,
+    MoveEdgeEvent,
+    PropertyChangedEvent,
+    PropertyChangedEventDetail,
+    SelectionChangedEvent
+} from "../components/graph-editor/graph-editor.component";
+import { Model, Plugin, ElementValue, ElementType } from "sinap-core";
+import { Value, Type } from "sinap-types";
+import { DoubleMap } from "./double-map";
+import { GraphController, UndoableEvent } from "./graph-controller";
+import { getPath } from "../util";
+
+export class Bridge {
+    private isSyncing = false;
+
+    private coreListener: (a: Value.Value, b: Value.Value, c: any) => void;
+    private drawableListener: (evt: PropertyChangedEvent<any>) => void;
+
+    constructor(private graph: GraphController, public core: ElementValue, public drawable: Drawable) {
+        const computedPropertyContext = new ComputedPropertyContext(core);
+        core.context = computedPropertyContext;
+
+        // Copy computed properties for the first time.
+        const copyComputedProperties = () => {
+            [...computedPropertyContext.properties.entries()].forEach(([key, [name, value]]) => {
+                this.graph.copyPropertyToDrawable(value, drawable, key);
+            });
+        };
+        copyComputedProperties();
+
+        this.coreListener = (_: Value.Value, value: Value.Value, other: any) => {
+            this.sync(() => {
+                // console.log(core, _, value, other);
+
+                computedPropertyContext.update();
+                copyComputedProperties();
+
+                [...core.type.members.entries()].map(([k, _]): [string, Value.Value] => [k, core.get(k)]).filter(([_, v]) => {
+                    if (v === value) {
+                        return true;
+                    } else if (v instanceof Value.Record) {
+                        for (const k of Object.keys(v.value)) {
+                            if (v.value[k] === value) {
+                                return true;
+                            }
+                        }
+                    } else if (v instanceof Value.Union && v.value === value) {
+                        return true;
+                    }
+
+                    return false;
+                }).forEach(([k, _]) => {
+                    this.graph.copyPropertyToDrawable(core.get(k), drawable, k);
+
+                    // TODO: Can only undo primitive changes.
+                    if (value instanceof Value.Primitive) {
+                        const undo: UndoableEvent = new UndoableEvent(true, () => {
+                            this.sync(() => {
+                                value.value = other.from;
+                                computedPropertyContext.update();
+                                copyComputedProperties();
+                                this.graph.copyPropertyToDrawable(core.get(k), drawable, k);
+                            });
+                            return new UndoableEvent(true, () => {
+                                this.sync(() => {
+                                    value.value = other.to;
+                                    computedPropertyContext.update();
+                                    copyComputedProperties();
+                                    this.graph.copyPropertyToDrawable(core.get(k), drawable, k);
+                                });
+                                return undo.copy();
+                            });
+                        });
+
+                        this.graph.changed.emit(undo);
+                    }
+                });
+            });
+        };
+
+        this.drawableListener = (evt: PropertyChangedEvent<any>) => {
+            const f = () => this.sync(() => {
+                const result = this.graph.copyPropertyToCore(this.drawable, this.core, evt.detail.key.toString());
+                if (result) {
+                    const previous = evt.detail.prev;
+                    const current = JSON.parse(JSON.stringify(evt.detail.curr)); // TODO: this feels pretty bad...
+                    const undo: UndoableEvent = new UndoableEvent(false, () => {
+                        this.sync(() => {
+                            (this.drawable as any)[evt.detail.key] = previous;
+                            this.graph.copyPropertyToCore(this.drawable, this.core, evt.detail.key.toString());
+                        });
+                        return new UndoableEvent(false, () => {
+                            this.sync(() => {
+                                (this.drawable as any)[evt.detail.key] = current;
+                                this.graph.copyPropertyToCore(this.drawable, this.core, evt.detail.key.toString());
+                            });
+
+                            return undo.copy();
+                        });
+                    });
+
+                    this.graph.changed.emit(undo);
+                }
+            });
+
+            f();
+        };
+
+        this.undeleted();
+    };
+
+    public undeleted() {
+        console.log("undeleted");
+        this.core.environment.listen(this.coreListener, () => true, this.core);
+        this.drawable.addEventListener("change", this.drawableListener);
+    }
+
+    public deleted() {
+        this.drawable.removeEventListener("change", this.drawableListener);
+    }
+
+    public sync(f: () => void) {
+        if (this.isSyncing) return;
+        this.isSyncing = true;
+        f();
+        this.isSyncing = false;
+    }
+}
+
+export class ComputedPropertyContext {
+    public readonly properties = new Map<string, [string, Value.Value]>();
+    public onUpdate?: (() => void) = undefined;
+
+    constructor(public readonly value: ElementValue) {
+        this.update();
+    };
+
+    update() {
+        [...this.value.type.pluginType.methods.entries()].filter(([_, method]) => method.isGetter).forEach(([key, _]) => {
+            let v = this.value.call(key);
+            if (v) {
+                this.properties.set(key, [this.value.type.prettyName(key), v]);
+            }
+        });
+
+        if (this.onUpdate) {
+            this.onUpdate();
+        }
+    }
+}

--- a/app/models/bridge.ts
+++ b/app/models/bridge.ts
@@ -53,8 +53,10 @@ export class Bridge {
                 }).forEach(([k, _]) => {
                     this.graph.copyPropertyToDrawable(core.get(k), drawable, k);
 
-                    // TODO: Can only undo primitive changes.
-                    if (value instanceof Value.Primitive) {
+                    console.log(value, other);
+
+                    // TODO: Can only undo primitive and union changes.
+                    if (value instanceof Value.Primitive || value instanceof Value.Union) {
                         const undo: UndoableEvent = new UndoableEvent(true, () => {
                             this.sync(() => {
                                 value.value = other.from;

--- a/app/models/graph-controller.ts
+++ b/app/models/graph-controller.ts
@@ -256,7 +256,8 @@ export class GraphController {
                     throw new Error("Trying to create a core element like a core element with a different type.");
                 }
             } else {
-                throw new OutOfSyncError();
+                console.log("TODO: What happens when the node you're creating a copy of is deleted?");
+                // throw new OutOfSyncError();
             }
         }
 

--- a/app/models/graph-controller.ts
+++ b/app/models/graph-controller.ts
@@ -159,8 +159,8 @@ export class GraphController {
 
         const movedListener = (evt: MoveEdgeEvent) => {
             const f = (): UndoableEvent => {
+                const replacement = this.addDrawable(evt.detail.replacement, undefined, evt.detail.original);
                 const original = this.removeDrawable(evt.detail.original);
-                const replacement = this.addDrawable(evt.detail.replacement);
 
                 const undo: UndoableEvent = new UndoableEvent(true, () => sync(() => {
                     this.undelete(original);
@@ -247,10 +247,17 @@ export class GraphController {
                         const likeValue = likeBridge.core.get(k);
                         const coreValue = core.get(k);
 
-                        // TODO: Handle more than Primitive values.
+                        // TODO: Handle more than primitive and union values.
                         if (likeValue instanceof Value.Primitive && coreValue instanceof Value.Primitive) {
                             coreValue.value = likeValue.value;
-                        }
+                        } else
+                            if (likeValue instanceof Value.Union && coreValue instanceof Value.Union) {
+                                if (likeValue.value instanceof Value.Primitive && coreValue.value instanceof Value.Primitive) {
+                                    coreValue.value.value = likeValue.value.value;
+                                } else if (likeValue.value instanceof Value.Literal && coreValue.value instanceof Value.Literal) {
+                                    coreValue.value = likeValue.value;
+                                }
+                            }
                     });
                 } else {
                     throw new Error("Trying to create a core element like a core element with a different type.");

--- a/app/models/graph-controller.ts
+++ b/app/models/graph-controller.ts
@@ -333,7 +333,7 @@ export class GraphController {
         Object.keys(drawable).forEach(this.copyPropertyToCore.bind(this, drawable, core));
     }
 
-    private readonly drawableKeys = new Set(["label", "color", "borderColor", "borderWidth", "lineWidth", "showSourceArrow", "showDestinationArrow", "image", "shape", "borderStyle", "lineStyle", "position"]);
+    private readonly drawableKeys = new Set(["label", "color", "borderColor", "borderWidth", "lineWidth", "showSourceArrow", "showDestinationArrow", "image", "shape", "borderStyle", "lineStyle", "position", "origin", "scale", "size"]);
 
     copyPropertyToDrawable(value: Value.Value | undefined, drawable: Drawable, key: string) {
         if (value === undefined || !this.drawableKeys.has(key)) {
@@ -372,10 +372,19 @@ export class GraphController {
             return;
         }
 
-        if (value instanceof Value.Record && key === "position") {
-            (drawable as DrawableNode).position = {
+        if (value instanceof Value.Record && (key === "position" || key === "origin")) {
+            (drawable as DrawableNode)[key] = {
                 x: (value.value.x as Value.Primitive).value as number,
                 y: (value.value.y as Value.Primitive).value as number
+            };
+
+            return;
+        }
+
+        if (value instanceof Value.Record && (key === "size")) {
+            (drawable as DrawableNode)[key] = {
+                width: (value.value.x as Value.Primitive).value as number,
+                height: (value.value.y as Value.Primitive).value as number
             };
 
             return;
@@ -420,9 +429,15 @@ export class GraphController {
             return true;
         }
 
-        if (value instanceof Value.Record && key === "position") {
+        if (value instanceof Value.Record && (key === "position" || key === "origin")) {
             (value.value.x as Value.Primitive).value = (drawable as any)[key].x;
             (value.value.y as Value.Primitive).value = (drawable as any)[key].y;
+            return true;
+        }
+
+        if (value instanceof Value.Record && key === "size") {
+            (value.value.width as Value.Primitive).value = (drawable as any)[key].width;
+            (value.value.height as Value.Primitive).value = (drawable as any)[key].height;
             return true;
         }
 

--- a/app/models/graph-controller.ts
+++ b/app/models/graph-controller.ts
@@ -22,73 +22,25 @@ import { Model, Plugin, ElementValue, ElementType } from "sinap-core";
 import { Value, Type } from "sinap-types";
 import { DoubleMap } from "./double-map";
 import { getPath } from "../util";
+import { Bridge } from "./bridge";
+export { Bridge, ComputedPropertyContext } from "./bridge";
+
 
 export class UndoableEvent {
-    constructor(public undo: () => void) { }
-}
+    private once = false;
+    constructor(public readonly reloadProgram: boolean, private _undo: () => UndoableEvent) { }
 
-export class Bridge {
-    private isSyncing = false;
+    public undo() {
+        if (this.once) {
+            throw new Error("Can only undo once!");
+        }
 
-    constructor(private graph: GraphController, public core: ElementValue, public drawable: Drawable) {
-        const computedPropertyContext = new ComputedPropertyContext(core);
-        core.context = computedPropertyContext;
+        this.once = true;
+        return this._undo();
+    }
 
-        // Copy computed properties for the first time.
-        const copyComputedProperties = () => {
-            [...computedPropertyContext.properties.entries()].forEach(([key, [name, value]]) => {
-                this.graph.copyPropertyToDrawable(value, drawable, key);
-            });
-        };
-        copyComputedProperties();
-
-        core.environment.listen((_, value, other) => {
-            this.sync(() => {
-                // console.log(core, _, value, other);
-
-                computedPropertyContext.update();
-                copyComputedProperties();
-
-                [...core.type.members.entries()].map(([k, _]): [string, Value.Value] => [k, core.get(k)]).filter(([_, v]) => {
-                    if (v === value) {
-                        return true;
-                    } else if (v instanceof Value.Record) {
-                        for (const k of Object.keys(v.value)) {
-                            if (v.value[k] === value) {
-                                return true;
-                            }
-                        }
-                    } else if (v instanceof Value.Union && v.value === value) {
-                        return true;
-                    }
-
-                    return false;
-                }).forEach(([k, _]) => {
-                    this.graph.copyPropertyToDrawable(core.get(k), drawable, k);
-                    this.graph.changed.emit(new UndoableEvent(() => {
-                        // TODO
-                    }));
-                });
-            });
-        }, () => true, core);
-
-        drawable.addEventListener("change", (evt: PropertyChangedEvent<any>) => {
-            this.sync(() => {
-                const result = this.graph.copyPropertyToCore(this.drawable, this.core, evt.detail.key.toString());
-                if (result) {
-                    this.graph.changed.emit(new UndoableEvent(() => {
-                        // TODO
-                    }));
-                }
-            });
-        });
-    };
-
-    private sync(f: () => void) {
-        if (this.isSyncing) return;
-        this.isSyncing = true;
-        f();
-        this.isSyncing = false;
+    public copy() {
+        return new UndoableEvent(this.reloadProgram, this._undo);
     }
 }
 
@@ -98,27 +50,7 @@ class OutOfSyncError extends Error {
     }
 }
 
-export class ComputedPropertyContext {
-    public readonly properties = new Map<string, [string, Value.Value]>();
-    public onUpdate?: (() => void) = undefined;
 
-    constructor(public readonly value: ElementValue) {
-        this.update();
-    };
-
-    update() {
-        [...this.value.type.pluginType.methods.entries()].filter(([_, method]) => method.isGetter).forEach(([key, _]) => {
-            let v = this.value.call(key);
-            if (v) {
-                this.properties.set(key, [this.value.type.prettyName(key), v]);
-            }
-        });
-
-        if (this.onUpdate) {
-            this.onUpdate();
-        }
-    }
-}
 
 export class GraphController {
     drawable: DrawableGraph;
@@ -191,25 +123,78 @@ export class GraphController {
 
 
         /* finally set up all the listeners after we copy all the elements */
-        this.drawable.addEventListener("created", (evt: DrawableEvent<DrawableElement>) => {
+        const createdListener = (evt: DrawableEvent<DrawableElement>) => {
             const bridges = evt.detail.drawables.map(d => this.addDrawable(d[0]));
-            this.changed.emit(new UndoableEvent(() => {
-                // TODO
-            }));
-        });
-        this.drawable.addEventListener("deleted", (evt: DrawableEvent<DrawableElement>) => {
+            this.changed.emit(new UndoableEvent(true, () => sync(() => deleteBridges(bridges))));
+        };
+
+        const deleteBridges = (bridges: Bridge[]): UndoableEvent => {
+            const edges = bridges.filter((b) => b.drawable instanceof DrawableEdge);
+            const nodes = bridges.filter((b) => b.drawable instanceof DrawableNode);
+
+            const deleted = [...edges, ...nodes].map((e) => {
+                this.drawable.delete(e.drawable as DrawableElement);
+                return this.removeDrawable(e.drawable);
+            });
+
+            return new UndoableEvent(true, () => sync(() => addBridges(deleted)));
+        };
+
+        const addBridges = (bridges: Bridge[]): UndoableEvent => {
+            const edges = bridges.filter((b) => b.drawable instanceof DrawableEdge);
+            const nodes = bridges.filter((b) => b.drawable instanceof DrawableNode);
+
+            const undeleted = [...nodes, ...edges].map((b) => {
+                this.undelete(b);
+                return b;
+            });
+
+            return new UndoableEvent(true, () => sync(() => deleteBridges(undeleted)));
+        };
+
+        const deletedListener = (evt: DrawableEvent<DrawableElement>) => {
             const bridges = evt.detail.drawables.map(d => this.removeDrawable(d[0]));
-            this.changed.emit(new UndoableEvent(() => {
-                // TODO
-            }));
-        });
-        this.drawable.addEventListener("moved", (evt: MoveEdgeEvent) => {
-            const original = this.removeDrawable(evt.detail.original);
-            const replacement = this.addDrawable(evt.detail.replacement);
-            this.changed.emit(new UndoableEvent(() => {
-                // TODO
-            }));
-        });
+            this.changed.emit(new UndoableEvent(true, () => sync(() => addBridges(bridges))));
+        };
+
+        const movedListener = (evt: MoveEdgeEvent) => {
+            const f = (): UndoableEvent => {
+                const original = this.removeDrawable(evt.detail.original);
+                const replacement = this.addDrawable(evt.detail.replacement);
+
+                const undo: UndoableEvent = new UndoableEvent(true, () => sync(() => {
+                    this.undelete(original);
+                    this.drawable.delete(replacement.drawable as DrawableElement);
+                    this.removeDrawable(replacement.drawable);
+
+                    return new UndoableEvent(true, () => sync(() => {
+                        this.undelete(replacement);
+                        this.drawable.delete(original.drawable as DrawableElement);
+                        this.removeDrawable(original.drawable);
+                        return undo.copy();
+                    }));
+                }));
+
+                return undo;
+            };
+            this.changed.emit(f());
+        };
+
+        const sync = (f: () => UndoableEvent) => {
+            this.drawable.removeEventListener("created", createdListener);
+            this.drawable.removeEventListener("deleted", deletedListener);
+            this.drawable.removeEventListener("moved", movedListener);
+            let r = f();
+            this.drawable.addEventListener("created", createdListener);
+            this.drawable.addEventListener("deleted", deletedListener);
+            this.drawable.addEventListener("moved", movedListener);
+
+            return r;
+        };
+
+        this.drawable.addEventListener("created", createdListener);
+        this.drawable.addEventListener("deleted", deletedListener);
+        this.drawable.addEventListener("moved", movedListener);
 
         this.drawable.addEventListener("select", (evt: SelectionChangedEvent) => this.setSelectedElements(evt.detail.curr));
         /* ************************************************************* */
@@ -217,6 +202,32 @@ export class GraphController {
 
         // side effect of selecting the graph
         this.setSelectedElements(undefined);
+    }
+
+    private undelete(bridge: Bridge) {
+        if (bridge.drawable instanceof DrawableElement) {
+            this.drawable.recreateItems(bridge.drawable);
+        }
+
+
+        // TODO: Sheyne, if you loved me you'd fix this before 1.0
+        const f = (v: Value.Value) => {
+            v.dependencyChildren.forEach(f);
+            this.core.environment.add(v);
+        };
+        f(bridge.core);
+
+
+
+        if (bridge.drawable instanceof DrawableNode) {
+            this.core.nodes.add(bridge.core);
+        }
+        if (bridge.drawable instanceof DrawableEdge) {
+            this.core.edges.add(bridge.core);
+        }
+
+        bridge.undeleted();
+        this.bridges.set(bridge.core, bridge.drawable, bridge);
     }
 
     private addDrawable(drawable: Drawable, _core?: ElementValue) {
@@ -236,6 +247,7 @@ export class GraphController {
     private removeDrawable(drawable: Drawable) {
         const bridge = this.bridges.getB(drawable);
         if (bridge) {
+            bridge.deleted();
             this.core.delete(bridge.core);
             this.bridges.delete(bridge.core, bridge.drawable);
         } else {
@@ -267,10 +279,6 @@ export class GraphController {
 
         this.copyPropertiesToCore(drawable, core);
         return core;
-    }
-
-    public applyUndoableEvent(event: UndoableEvent) {
-        // TODO:
     }
 
 


### PR DESCRIPTION
#134 

~There's still the bug with adding back ElementValue's to the Model. Occasionally you can trigger a "Value not in Environment" error, still.~ #326

Other than that hopefully this doesn't cause errors.

I've debounced undoable events to ~200~ 100 milliseconds. This handles cases such as when you move multiple nodes.. or in the future when the properties panel can edit multiple nodes at a time.

I'll probably keep this regardless, as it allows me to debounce how often a new Program is compiled from the plugin, though events to the graph controller should still be as debounced as possible. 

I'm also trying to make a distinction between events that are merely visible, and events that should trigger the plugin to recompile. (moving nodes doesn't trigger a recompile, when I add zooming, nor will that.)

Note: origin and zoom and currently not saved to the core model and therefore not undoable... working on it.