### PR TITLE
Linux package manager

### DIFF
--- a/app/services/plugin.service.ts
+++ b/app/services/plugin.service.ts
@@ -12,7 +12,7 @@ import { PythonPluginLoader } from "sinap-python-loader";
 const app = remote.app;
 const LOG = getLogger("plugin.service");
 
-export const PLUGIN_DIRECTORY = IS_PRODUCTION ? path.join(app.getPath("userData"), "plugins") : "./plugins";
+export const PLUGIN_DIRECTORY = IS_PRODUCTION ? path.join(app.getPath("userData"), "plugins") : path.join(app.getAppPath(), "plugins");
 export const ROOT_DIRECTORY = IS_PRODUCTION ? path.join(app.getAppPath(), "..", "app") : ".";
 
 class PluginHolder {
@@ -210,12 +210,15 @@ export class PluginService {
         let dirs: string[] = [];
 
         try {
-            dirs = await subdirs(PLUGIN_DIRECTORY);
-        } catch (err) {
-            if (err && err.code === "ENOENT") {
-                await createDir(PLUGIN_DIRECTORY);
-                dirs = [];
+            const unfiltered = await subdirs(PLUGIN_DIRECTORY);
+            for (const dir of unfiltered) {
+                const files = await dirFiles(dir);
+                if (files.findIndex(file => file === "package.json") >= 0)
+                    dirs.push(dir);
             }
+        } catch (err) {
+            if (err && err.code === "ENOENT")
+                await createDir(PLUGIN_DIRECTORY);
         }
 
         const plugins = await somePromises(dirs.map(dir => this.loadPlugin(dir)), LOG);
@@ -254,8 +257,13 @@ export class PluginService {
     public async importPlugin(dir: string): Promise<void> {
         // Recursively progress through directories until we get interpreter info.
         const dest = path.join(PLUGIN_DIRECTORY, path.basename(dir));
-        LOG.log(`Importing plugins from ${dir} to ${dest}.`);
-        await copy(dir, dest);
+        if (dest === dir) {
+            return new Promise<void>((resolve, reject) => resolve());
+        }
+        else {
+            LOG.log(`Importing plugins from ${dir} to ${dest}.`);
+            await copy(dir, dest);
+        }
     }
 
     public async unload(plugin: Plugin): Promise<void> {

--- a/app/services/plugin.service.ts
+++ b/app/services/plugin.service.ts
@@ -258,9 +258,8 @@ export class PluginService {
         // Recursively progress through directories until we get interpreter info.
         const dest = path.join(PLUGIN_DIRECTORY, path.basename(dir));
         if (dest === dir) {
-            return new Promise<void>((resolve, reject) => resolve());
-        }
-        else {
+            return Promise.resolve();
+        } else {
             LOG.log(`Importing plugins from ${dir} to ${dest}.`);
             await copy(dir, dest);
         }

--- a/app/util.ts
+++ b/app/util.ts
@@ -54,22 +54,16 @@ export function getExpected(program: Program) {
 
 
 // Similar to Promise.all. However, this will always resolve and ignore rejected promises.
-export function somePromises<T>(promises: Iterable<Promise<T>>, logger: Logger): Promise<T[]> {
-    let result: Promise<T[]> = Promise.resolve([]);
-
+export async function somePromises<T>(promises: Iterable<Promise<T>>, logger: Logger): Promise<T[]> {
+    const arr = [] as T[];
     for (const promise of promises) {
-        result = result.then((arr) => {
-            return promise.then((ele) => {
-                arr.push(ele);
-                return arr;
-            }).catch((err) => {
-                logger.log(err);
-                return arr;
-            });
-        });
+        try {
+            arr.push(await promise);
+        } catch (err) {
+            logger.log(err);
+        }
     }
-
-    return result;
+    return Promise.resolve(arr);
 }
 
 export function getPath(name: string) {
@@ -151,7 +145,6 @@ export async function requestOpenDirs(name?: string): Promise<string[]> {
     const result = new NodePromise<string[]>();
     dialog.showOpenDialog(remote.BrowserWindow.getFocusedWindow(), {
         properties: ["openDirectory"],
-        filters: [ZIP_FILE_FILTER],
         defaultPath: name
     }, names => result.cb(names ? null : "Directory selection cancelled", names));
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,14 +60,19 @@ module.exports = (env = {}) => { // pass command line arguments like `webpack ..
         plugins: [
             new webpack.NoEmitOnErrorsPlugin(),
 
+            /*** # 5/9/2017                                                                     ***/
+            /*** See: https://github.com/webpack/webpack/issues/2545#issuecomment-300134407     ***/
+            /*** Removing uglify for the time being.                                            ***/
+            /*** See also: https://github.com/webpack-contrib/uglifyjs-webpack-plugin           ***/
+            /***           for up-to-date instructions on how to use the webpack uglify plugin. ***/
             // Note because our project is ES6, we're using the harmony branch of uglifyjs
-            new webpack.optimize.UglifyJsPlugin({
-                debug: false,
-                minimize: true,
-                output: {
-                    comments: false
-                },
-            }),
+            // new webpack.optimize.UglifyJsPlugin({
+            //     debug: false,
+            //     minimize: true,
+            //     output: {
+            //         comments: false
+            //     },
+            // }),
         ]
     };
 


### PR DESCRIPTION
Fixes issues with package management on Linux (and potentially other OS's).

* copying to the same source and destination is now skipped
* subdirectories without a `package.json` are no longer attempted to be imported
* removed file filter from `requestOpenDirs`
* cleaned `somePromises` a little
* removed uglifyjs from production build (see inline comment)